### PR TITLE
Contracts first version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
-name: test
+name: Foundry tests
 
-on: workflow_dispatch
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - "**"
 
 env:
   FOUNDRY_PROFILE: ci

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Plague Game
+
+A mysterious plague is infecting everyone in the town. You must drink potions to survive the plague. Will you be the last ones standing?
+
+___
+
+## Install foundry
+
+Foundry documentation can be found [here](https://book.getfoundry.sh/forge/index.html).
+
+Open your terminal and type in the following command:
+
+```
+curl -L https://foundry.paradigm.xyz | bash
+```
+
+This will download foundryup. Then install Foundry by running:
+
+```
+foundryup
+```
+
+To update foundry after installation, simply run `foundryup` again, and it will update to the latest Foundry release.
+
+## Install dependencies
+
+To install dependencies, run the following to install dependencies:
+
+```
+forge install
+```
+
+___
+
+## Tests
+
+To run tests, run the following command:
+
+```
+forge test
+```

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,4 @@ libs = ['lib']
 
 gas_reports = ["PlagueGame"]
 
-[fuzz]
-runs = 32
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/script/CreateNFTs.s.sol
+++ b/script/CreateNFTs.s.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+
+import "test/mocks/ERC721.sol";
+
+contract CreateNFTScript is Script {
+    uint256 mintNumber = 5;
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+        ERC721Mock villagers = new ERC721Mock();
+        ERC721Mock potions = new ERC721Mock();
+
+        villagers.mint(mintNumber);
+        potions.mint(mintNumber);
+        vm.stopBroadcast();
+    }
+}

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+
+import "src/PlagueGame.sol";
+import "test/mocks/ERC721.sol";
+import "chainlink/interfaces/VRFCoordinatorV2Interface.sol";
+
+contract DeployScript is Script {
+    uint256 playerNumberToEndGame = 10;
+    uint256[] public infectedDoctorsPerEpoch =
+        [2_000, 2_000, 2_000, 3_000, 3_000, 3_000, 4_000, 4_000, 4_000, 5_000, 5_000, 5_000];
+    uint256 epochDuration = 1 days;
+
+    ERC721Mock villagers = ERC721Mock(0x6a0e6AA00A85d544f2F6bC6D940aDFBd4FD8b4b9);
+    ERC721Mock potions = ERC721Mock(0xd7C046164bd7D84Db761bD9F97A5AF8D16B93332);
+    VRFCoordinatorV2Interface coordinator = VRFCoordinatorV2Interface(0x2eD832Ba664535e5886b75D64C46EB9a228C2610);
+
+    uint64 subscriptionId = 139;
+    bytes32 keyHash = 0x354d2f95da55398f44b7cff77da56283d9c6c829a4bdf1bbcaf2ad6a4d081f61;
+    uint32 maxGas = 800_000;
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+        PlagueGame plagueGame = new PlagueGame(
+            villagers,
+            potions,
+            infectedDoctorsPerEpoch,
+            playerNumberToEndGame,
+            epochDuration,
+            coordinator,
+            subscriptionId,
+            keyHash,
+            maxGas
+        );
+
+        coordinator.addConsumer(subscriptionId, address(plagueGame));
+        plagueGame.startGame();
+        vm.stopBroadcast();
+
+        console.log("Contract deployed at address: ", address(plagueGame));
+    }
+}

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "openzeppelin/token/ERC721//extensions/IERC721Enumerable.sol";
+
+interface IPlagueGame {
+    /// @dev Different statuses a doctor can have
+    enum Status {
+        Dead,
+        Healthy,
+        Infected
+    }
+
+    /// Game events
+    event GameStarted();
+    event RandomWordsFulfilled(uint256 epoch, uint256 requestId);
+    event DoctorsInfectedThisEpoch(uint256 indexed epoch, uint256 infectedDoctors);
+    event DoctorsDeadThisEpoch(uint256 indexed epoch, uint256 deadDoctors);
+    event GameOver();
+    event PrizeWithdrawalAllowed(bool newValue);
+    event PrizeWithdrawn(uint256 indexed doctorId, uint256 prize);
+    event PrizePotIncreased(uint256 amount);
+    event FundsEmergencyWithdraw(uint256 amount);
+
+    /// Individual events
+    event Sick(uint256 indexed doctorId);
+    event Cured(uint256 indexed doctorId);
+    event Dead(uint256 indexed doctorId);
+
+    function doctors() external view returns (IERC721Enumerable);
+    function potions() external view returns (IERC721Enumerable);
+
+    function playerNumberToEndGame() external view returns (uint256);
+    function infectionPercentagePerEpoch(uint256 epoch) external view returns (uint256);
+
+    function currentEpoch() external view returns (uint256);
+    function epochDuration() external view returns (uint256);
+    function epochStartTime() external view returns (uint256);
+
+    function doctorStatus(uint256 doctorId) external view returns (Status);
+
+    function infectedDoctorsPerEpoch(uint256 epoch) external view returns (uint256);
+    function deadDoctorsPerEpoch(uint256 epoch) external view returns (uint256);
+    function withdrewPrize(uint256 doctorId) external view returns (bool);
+
+    function isGameOver() external view returns (bool);
+    function isGameStarted() external view returns (bool);
+    function prizePot() external view returns (uint256);
+    function prizeWithdrawalAllowed() external view returns (bool);
+
+    function getHealthyDoctorsNumber() external view returns (uint256);
+    function initializeGame(uint256 _amount) external;
+    function allowPrizeWithdraw(bool _status) external;
+    function startGame() external;
+    function startEpoch() external;
+    function endEpoch() external;
+    function drinkPotion(uint256 _doctorId, uint256 _potionId) external;
+    function withdrawPrize(uint256 _doctorId) external;
+    function withdrawFunds() external;
+}

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.13;
 
 import "openzeppelin/token/ERC721//extensions/IERC721Enumerable.sol";
 
+error InvalidPlayerNumberToEndGame();
 error InvalidInfectionPercentage();
+error InvalidEpochDuration();
 error TooManyInitialized();
 error CollectionTooBig();
 error GameAlreadyStarted();

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -3,6 +3,25 @@ pragma solidity ^0.8.13;
 
 import "openzeppelin/token/ERC721//extensions/IERC721Enumerable.sol";
 
+error InvalidInfectionPercentage();
+error TooManyInitialized();
+error CollectionTooBig();
+error GameAlreadyStarted();
+error GameNotStarted();
+error GameNotOver();
+error GameIsClosed();
+error EpochNotReadyToEnd();
+error EpochAlreadyEnded();
+error DoctorNotInfected();
+error UpdateToSameStatus();
+error InvalidRequestId();
+error VRFResponseMissing();
+error VRFRequestAlreadyAsked();
+error CantAddPrizeIfGameIsOver();
+error NotAWinner();
+error WithdrawalClosed();
+error FundsTransferFailed();
+
 interface IPlagueGame {
     /// @dev Different statuses a doctor can have
     enum Status {

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -51,6 +51,7 @@ interface IPlagueGame {
 
     function playerNumberToEndGame() external view returns (uint256);
     function infectionPercentagePerEpoch(uint256 epoch) external view returns (uint256);
+    function totalDefinedEpochNumber() external view returns (uint256);
 
     function currentEpoch() external view returns (uint256);
     function epochDuration() external view returns (uint256);

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -1,4 +1,229 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-contract PlagueGame {}
+import "openzeppelin/access/Ownable2Step.sol";
+import "openzeppelin/utils/structs/EnumerableSet.sol";
+import "openzeppelin/token/ERC721//extensions/IERC721Enumerable.sol";
+import "chainlink/VRFConsumerBaseV2.sol";
+import "chainlink/interfaces/VRFCoordinatorV2Interface.sol";
+
+import "forge-std/console.sol";
+
+contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
+    event Sick(uint256 indexed villagerId);
+    event Cured(uint256 indexed villagerId);
+    event Dead(uint256 indexed villagerId);
+    event RandomWordsFulfilled(uint256 epoch, uint256 requestId);
+
+    using EnumerableSet for EnumerableSet.UintSet;
+
+    enum Status {
+        Unknown,
+        Healthy,
+        Infected,
+        Dead
+    }
+
+    IERC721Enumerable public immutable villagers;
+    IERC721Enumerable public immutable potions;
+    VRFCoordinatorV2Interface private immutable vrfCoordinator;
+    uint256 public immutable playerNumberToEndGame;
+
+    uint256 private constant BASIS_POINT = 10_000;
+
+    mapping(uint256 => Status) public villagerStatus;
+    mapping(uint256 => uint256) public epochVRFRequest;
+    mapping(uint256 => uint256[]) public epochVRFNumber;
+    mapping(uint256 => bool) public epochStarted;
+
+    bool public isGameOver;
+    bool public canWithdraw;
+    uint256 public prizePot;
+    // mapping(uint256 => uint256) public infectionPercentagePerRound;
+
+    uint256[] public infectionPercentagePerRound;
+    uint256 public immutable totalRoundNumber;
+    mapping(uint256 => uint256) public infectedDoctorsPerEpoch;
+
+    uint256 public currentEpoch;
+    bool public epochLocked;
+
+    EnumerableSet.UintSet healthyVillagers;
+
+    uint256 private immutable villagerNumber;
+    uint256 public lastVillagerUpdated;
+
+    modifier gameOn() {
+        if (isGameOver) {
+            revert("game over");
+        }
+        _;
+    }
+
+    constructor(
+        IERC721Enumerable _villagers,
+        IERC721Enumerable _potions,
+        uint256[] memory _rounds,
+        uint256 _playerNumberToEndGame,
+        VRFCoordinatorV2Interface _vrfCoordinator
+    ) VRFConsumerBaseV2(address(_vrfCoordinator)) {
+        villagers = _villagers;
+        vrfCoordinator = _vrfCoordinator;
+        villagerNumber = _villagers.totalSupply();
+        playerNumberToEndGame = _playerNumberToEndGame;
+
+        for (uint256 i = 0; i < villagerNumber; i++) {
+            healthyVillagers.add(i);
+            villagerStatus[i] = Status.Healthy;
+        }
+
+        if (villagerNumber > 1000) {
+            revert();
+        }
+
+        for (uint256 i = 0; i < _rounds.length; i++) {
+            if (_rounds[i] > BASIS_POINT) {
+                revert();
+            }
+        }
+
+        potions = _potions;
+        infectionPercentagePerRound = _rounds;
+        totalRoundNumber = _rounds.length;
+    }
+
+    function getHealthyVillagersNumber() external view returns (uint256 healthyVillagersNumber) {
+        healthyVillagersNumber = healthyVillagers.length();
+    }
+
+    function startGame() external onlyOwner {
+        ++currentEpoch;
+        _requestRandomWords();
+    }
+
+    function startEpoch() public gameOn {
+        uint256[] memory randomNumbers = epochVRFNumber[epochVRFRequest[currentEpoch]];
+
+        if (randomNumbers.length == 0) {
+            revert("need to ask for VRF");
+        }
+
+        if (epochStarted[currentEpoch] == true) {
+            revert("epoch already started");
+        }
+
+        epochStarted[currentEpoch] = true;
+
+        uint256 healthyVillagersNumber = healthyVillagers.length();
+        uint256 toMakeSick = healthyVillagersNumber * infectionPercentagePerRound[currentEpoch] / BASIS_POINT;
+
+        _infectRandomVillagers(healthyVillagersNumber, toMakeSick, randomNumbers);
+    }
+
+    function endEpoch() external gameOn {
+        for (uint256 i = 0; i < villagerNumber; i++) {
+            if (villagerStatus[i] == Status.Infected) {
+                villagerStatus[i] = Status.Dead;
+                // emit Dead(i);
+            }
+        }
+
+        if (healthyVillagers.length() <= 10 || currentEpoch == 12) {
+            isGameOver = true;
+            return;
+        }
+
+        ++currentEpoch;
+        _requestRandomWords();
+    }
+
+    function drinkPotion(uint256 _villagerId, uint256 _potionId) external {
+        if (villagerStatus[_villagerId] != Status.Infected) {
+            revert();
+        }
+
+        villagerStatus[_villagerId] = Status.Healthy;
+        healthyVillagers.add(_villagerId);
+
+        _burnPotion(_potionId);
+
+        // emit Cured(_villagerId);
+    }
+
+    // Loops through the healthy villagers and infects them
+    // until the number of infected villagers is equal to the
+    // requested number
+    function _infectRandomVillagers(
+        uint256 _healthyVillagersNumber,
+        uint256 _toMakeSick,
+        uint256[] memory _randomNumbers
+    ) private {
+        uint256 madeSick;
+        uint256 villagerId;
+        uint256 randomNumber;
+        uint256 randomNumberId;
+        uint256 healthyVillagerId;
+        uint256 randomNumberSliceOffset;
+
+        while (madeSick < _toMakeSick) {
+            randomNumber = _randomNumbers[randomNumberId];
+            healthyVillagerId =
+                _sliceRandomNumber(_randomNumbers[randomNumberId], randomNumberSliceOffset++) % _healthyVillagersNumber;
+            villagerId = healthyVillagers.at(healthyVillagerId);
+
+            healthyVillagers.remove(villagerId);
+            villagerStatus[villagerId] = Status.Infected;
+            --_healthyVillagersNumber;
+            // emit Sick(villagerId);
+
+            ++madeSick;
+            if (randomNumberSliceOffset == 8) {
+                randomNumberSliceOffset = 0;
+                ++randomNumberId;
+            } else {
+                ++randomNumberSliceOffset;
+            }
+        }
+    }
+
+    function _burnPotion(uint256 _potionId) internal {
+        potions.transferFrom(msg.sender, address(0xdead), _potionId);
+    }
+
+    function _sliceRandomNumber(uint256 _randomNumber, uint256 _offset)
+        internal
+        pure
+        returns (uint32 slicedRadomNumber)
+    {
+        unchecked {
+            slicedRadomNumber = uint32(_randomNumber >> 32 * _offset);
+        }
+    }
+
+    // Random numbers will be sliced into uint32 to reduce the amount of random numbers needed
+    // Since the array to select the random villager will be at most 1k, uint32 numbers are enough
+    // to get sufficiently random numbers
+    function _requestRandomWords() private {
+        if (epochVRFNumber[epochVRFRequest[currentEpoch]].length != 0) {
+            revert("request locked");
+        }
+        uint256 infectedDoctors = healthyVillagers.length() * infectionPercentagePerRound[currentEpoch] / BASIS_POINT;
+        infectedDoctorsPerEpoch[currentEpoch] = infectedDoctors;
+        uint32 wordsNumber = uint32(infectedDoctors / 8 + 1);
+
+        epochVRFRequest[currentEpoch] = vrfCoordinator.requestRandomWords("", 1, 5, 800_000, wordsNumber);
+    }
+
+    function fulfillRandomWords(uint256 requestId, uint256[] memory randomWords) internal override {
+        // Checks if this is the correct request
+        if (requestId != epochVRFRequest[currentEpoch]) {
+            revert("wrong request");
+        }
+
+        epochVRFNumber[requestId] = randomWords;
+
+        emit RandomWordsFulfilled(currentEpoch, requestId);
+
+        // startEpoch();
+    }
+}

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -195,6 +195,17 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
         uint256 currentEpochCached = currentEpoch;
 
         uint256 toMakeSick = healthyDoctorsNumber * _getinfectionRate(currentEpochCached) / BASIS_POINT;
+
+        // Need at least one doctor to be infected, otherwise the game will never end
+        if (toMakeSick == 0) {
+            toMakeSick = 1;
+        }
+
+        // Need at least one doctor left healthy, otherwise the game could end up with no winners
+        if (toMakeSick == healthyDoctorsNumber) {
+            toMakeSick -= 1;
+        }
+
         infectedDoctorsPerEpoch[currentEpoch] = toMakeSick;
 
         _infectRandomDoctors(healthyDoctorsNumber, toMakeSick, randomNumber);

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import "openzeppelin/access/Ownable2Step.sol";
+import "openzeppelin/access/Ownable.sol";
 import "openzeppelin/utils/structs/EnumerableSet.sol";
 import "openzeppelin/token/ERC721//extensions/IERC721Enumerable.sol";
 import "chainlink/VRFConsumerBaseV2.sol";
@@ -25,7 +25,7 @@ error NotAWinner();
 error WithdrawalClosed();
 error FundsTransferFailed();
 
-contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
+contract PlagueGame is Ownable, VRFConsumerBaseV2 {
     using EnumerableSet for EnumerableSet.UintSet;
 
     /// Game events
@@ -34,13 +34,13 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     event DoctorsInfectedThisEpoch(uint256 indexed epoch, uint256 deadDoctors);
     event DoctorsDeadThisEpoch(uint256 indexed epoch, uint256 deadDoctors);
     event GameOver();
-    event PrizeWithdrawn(uint256 indexed villagerId, uint256 prize);
+    event PrizeWithdrawn(uint256 indexed doctorId, uint256 prize);
     event PrizePotIncreased(uint256 amount);
 
     /// Individual events
-    event Sick(uint256 indexed villagerId);
-    event Cured(uint256 indexed villagerId);
-    event Dead(uint256 indexed villagerId);
+    event Sick(uint256 indexed doctorId);
+    event Cured(uint256 indexed doctorId);
+    event Dead(uint256 indexed doctorId);
 
     /// @dev Different statuses a doctor can have
     enum Status {
@@ -50,29 +50,29 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     }
 
     /// @notice Address of the doctor collection contract
-    IERC721Enumerable public immutable villagers;
+    IERC721Enumerable public immutable doctors;
     /// @notice Address of the potion collection contract
     IERC721Enumerable public immutable potions;
     /// @notice Number of doctors still alive triggering the end of the game
     uint256 public immutable playerNumberToEndGame;
     /// @notice Percentage of doctors that will  be infected each epoch
-    uint256[] public infectionPercentagePerRound;
+    uint256[] public infectionPercentagePerEpoch;
     /// @notice Total number of epochs
-    uint256 public immutable totalRoundNumber;
+    uint256 public immutable totalEpochNumber;
     /// @dev Number of doctors in the collection
-    uint256 private immutable villagerNumber;
+    uint256 private immutable doctorNumber;
 
-    /// @notice Current epoch. Epoch is incremented at the beginning of each round
+    /// @notice Current epoch. Epoch is incremented at the beginning of each epoch
     uint256 public currentEpoch;
     /// @notice Duration of each epoch in seconds
     uint256 public epochDuration;
     /// @notice Start time of the latest epoch
     uint256 public epochStartTime;
 
-    /// @notice Status of the villagers
-    mapping(uint256 => Status) public villagerStatus;
+    /// @notice Status of the doctors
+    mapping(uint256 => Status) public doctorStatus;
 
-    /// @notice Stores the number of doctors infect each round
+    /// @notice Stores the number of doctors infected each epoch
     mapping(uint256 => uint256) public infectedDoctorsPerEpoch;
     /// @notice VRF request IDs for each epoch
     mapping(uint256 => uint256) public epochVRFRequest;
@@ -81,12 +81,10 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     /// @notice Stores if a user already claimed his prize for a doctors he owns
     mapping(uint256 => bool) public withdrewPrize;
     /// @dev Stores if an epoch has started
-    mapping(uint256 => bool) private epochStarted;
-    /// @dev Stores if an epoch has started
     mapping(uint256 => bool) private epochEnded;
 
-    /// @dev List of healthy villagers
-    EnumerableSet.UintSet private healthyVillagers;
+    /// @dev List of healthy doctors
+    EnumerableSet.UintSet private healthyDoctors;
 
     /// @notice True is the game is over
     bool public isGameOver;
@@ -117,9 +115,9 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     }
 
     /// @dev Constructor
-    /// @param _villagers Address of the doctor collection contract
+    /// @param _doctors Address of the doctor collection contract
     /// @param _potions Address of the potion collection contract
-    /// @param _infectionPercentagePerRound Percentage of doctors that will  be infected each epoch
+    /// @param _infectionPercentagePerEpoch Percentage of doctors that will  be infected each epoch
     /// @param _playerNumberToEndGame Number of doctors still alive triggering the end of the game
     /// @param _epochDuration Duration of each epoch in seconds
     /// @param _vrfCoordinator Address of the VRF coordinator
@@ -127,9 +125,9 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     /// @param _keyHash VRF key hash
     /// @param _maxGas Max gas used on the VRF callback
     constructor(
-        IERC721Enumerable _villagers,
+        IERC721Enumerable _doctors,
         IERC721Enumerable _potions,
-        uint256[] memory _infectionPercentagePerRound,
+        uint256[] memory _infectionPercentagePerEpoch,
         uint256 _playerNumberToEndGame,
         uint256 _epochDuration,
         VRFCoordinatorV2Interface _vrfCoordinator,
@@ -137,24 +135,24 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         bytes32 _keyHash,
         uint32 _maxGas
     ) VRFConsumerBaseV2(address(_vrfCoordinator)) {
-        for (uint256 i = 0; i < _infectionPercentagePerRound.length; i++) {
-            if (_infectionPercentagePerRound[i] > BASIS_POINT) {
+        for (uint256 i = 0; i < _infectionPercentagePerEpoch.length; i++) {
+            if (_infectionPercentagePerEpoch[i] > BASIS_POINT) {
                 revert InvalidInfectionPercentage();
             }
         }
 
-        villagers = _villagers;
+        doctors = _doctors;
         vrfCoordinator = _vrfCoordinator;
-        villagerNumber = _villagers.totalSupply();
+        doctorNumber = _doctors.totalSupply();
 
-        if (villagerNumber > 1200) {
+        if (doctorNumber > 1200) {
             revert CollectionTooBig();
         }
 
         playerNumberToEndGame = _playerNumberToEndGame;
         potions = _potions;
-        infectionPercentagePerRound = _infectionPercentagePerRound;
-        totalRoundNumber = _infectionPercentagePerRound.length;
+        infectionPercentagePerEpoch = _infectionPercentagePerEpoch;
+        totalEpochNumber = _infectionPercentagePerEpoch.length;
         epochDuration = _epochDuration;
 
         // VRF setup
@@ -164,25 +162,25 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     }
 
     /// @notice Gets the number of healthy doctors
-    /// @return healthyVillagersNumber Number of healthy doctors
-    function getHealthyVillagersNumber() external view returns (uint256 healthyVillagersNumber) {
-        healthyVillagersNumber = healthyVillagers.length();
+    /// @return healthyDoctorsNumber Number of healthy doctors
+    function getHealthyDoctorsNumber() external view returns (uint256 healthyDoctorsNumber) {
+        healthyDoctorsNumber = healthyDoctors.length();
     }
 
     /// @notice Initializes the game
     /// @dev This function is very expensive is gas, that's why it needs to be called several times
     /// @param _amount Amount of doctors to initialize
     function initializeGame(uint256 _amount) external {
-        uint256 lastVillagerUpdated = healthyVillagers.length();
+        uint256 lastDoctorUpdated = healthyDoctors.length();
 
-        if (lastVillagerUpdated + _amount > villagerNumber) {
+        if (lastDoctorUpdated + _amount > doctorNumber) {
             revert TooManyInitialized();
         }
 
-        uint256 lastIndex = lastVillagerUpdated + _amount;
-        for (uint256 i = lastVillagerUpdated; i < lastIndex; i++) {
-            villagerStatus[i] = Status.Healthy;
-            healthyVillagers.add(i);
+        uint256 lastIndex = lastDoctorUpdated + _amount;
+        for (uint256 i = lastDoctorUpdated; i < lastIndex; i++) {
+            doctorStatus[i] = Status.Healthy;
+            healthyDoctors.add(i);
         }
     }
 
@@ -206,7 +204,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
             revert GameAlreadyStarted();
         }
 
-        if (healthyVillagers.length() < villagerNumber) {
+        if (healthyDoctors.length() < doctorNumber) {
             revert GameNotStarted();
         }
 
@@ -225,13 +223,12 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
             revert VRFResponseMissing();
         }
 
-        epochStarted[currentEpoch] = true;
         epochStartTime = block.timestamp;
 
-        uint256 healthyVillagersNumber = healthyVillagers.length();
-        uint256 toMakeSick = healthyVillagersNumber * infectionPercentagePerRound[currentEpoch - 1] / BASIS_POINT;
+        uint256 healthyDoctorsNumber = healthyDoctors.length();
+        uint256 toMakeSick = healthyDoctorsNumber * infectionPercentagePerEpoch[currentEpoch - 1] / BASIS_POINT;
 
-        _infectRandomVillagers(healthyVillagersNumber, toMakeSick, randomNumbers);
+        _infectRandomDoctors(healthyDoctorsNumber, toMakeSick, randomNumbers);
 
         emit DoctorsInfectedThisEpoch(currentEpoch, toMakeSick);
     }
@@ -249,9 +246,9 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         epochEnded[currentEpoch] = true;
 
         uint256 deads;
-        for (uint256 i = 0; i < villagerNumber; ++i) {
-            if (villagerStatus[i] == Status.Infected) {
-                villagerStatus[i] = Status.Dead;
+        for (uint256 i = 0; i < doctorNumber; ++i) {
+            if (doctorStatus[i] == Status.Infected) {
+                doctorStatus[i] = Status.Dead;
                 ++deads;
                 emit Dead(i);
             }
@@ -259,7 +256,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
 
         emit DoctorsDeadThisEpoch(currentEpoch, deads);
 
-        if (healthyVillagers.length() <= 10 || currentEpoch == 12) {
+        if (healthyDoctors.length() <= 10 || currentEpoch == 12) {
             isGameOver = true;
             emit GameOver();
             return;
@@ -270,38 +267,38 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
 
     /// @notice Burns a potion to cure a doctor
     /// @dev User needs to have given approval to the contract
-    /// @param _villagerId ID of the doctor to cure
+    /// @param _doctorId ID of the doctor to cure
     /// @param _potionId ID of the potion to use
-    function drinkPotion(uint256 _villagerId, uint256 _potionId) external {
-        if (villagerStatus[_villagerId] != Status.Infected) {
+    function drinkPotion(uint256 _doctorId, uint256 _potionId) external {
+        if (doctorStatus[_doctorId] != Status.Infected) {
             revert DoctorNotInfected();
         }
 
-        villagerStatus[_villagerId] = Status.Healthy;
-        healthyVillagers.add(_villagerId);
+        doctorStatus[_doctorId] = Status.Healthy;
+        healthyDoctors.add(_doctorId);
 
         _burnPotion(_potionId);
 
-        emit Cured(_villagerId);
+        emit Cured(_doctorId);
     }
 
     /// @notice Withdraws the prize for a winning doctor
-    /// @param _villagerId ID of the doctor to withdraw the prize for
-    function withdrawPrize(uint256 _villagerId) external {
+    /// @param _doctorId ID of the doctor to withdraw the prize for
+    function withdrawPrize(uint256 _doctorId) external {
         if (!prizeWithdrawalAllowed) {
             revert WithdrawalClosed();
         }
 
         if (
-            villagerStatus[_villagerId] != Status.Healthy || villagers.ownerOf(_villagerId) != msg.sender
-                || withdrewPrize[_villagerId]
+            doctorStatus[_doctorId] != Status.Healthy || doctors.ownerOf(_doctorId) != msg.sender
+                || withdrewPrize[_doctorId]
         ) {
             revert NotAWinner();
         }
 
-        withdrewPrize[_villagerId] = true;
+        withdrewPrize[_doctorId] = true;
 
-        uint256 prize = prizePot / healthyVillagers.length();
+        uint256 prize = prizePot / healthyDoctors.length();
 
         (bool success,) = payable(msg.sender).call{value: prize}("");
 
@@ -309,7 +306,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
             revert FundsTransferFailed();
         }
 
-        emit PrizeWithdrawn(_villagerId, prize);
+        emit PrizeWithdrawn(_doctorId, prize);
     }
 
     /// @dev Send AVAX to the contract to increase the prize pot
@@ -318,34 +315,32 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         emit PrizePotIncreased(msg.value);
     }
 
-    /// @dev Loops through the healthy villagers and infects them until
-    /// the number of infected villagers is equal to the requested number
+    /// @dev Loops through the healthy doctors and infects them until
+    /// the number of infected doctors is equal to the requested number
     /// @dev Each VRF random number is used 8 times
-    /// @param _healthyVillagersNumber Number of healthy villagers
-    /// @param _toMakeSick Number of villagers to infect
-    /// @param _randomNumbers Random numbers provided by VRF to use to infect villagers
-    function _infectRandomVillagers(
-        uint256 _healthyVillagersNumber,
-        uint256 _toMakeSick,
-        uint256[] memory _randomNumbers
-    ) private {
+    /// @param _healthyDoctorsNumber Number of healthy doctors
+    /// @param _toMakeSick Number of doctors to infect
+    /// @param _randomNumbers Random numbers provided by VRF to use to infect doctors
+    function _infectRandomDoctors(uint256 _healthyDoctorsNumber, uint256 _toMakeSick, uint256[] memory _randomNumbers)
+        private
+    {
         uint256 madeSick;
-        uint256 villagerId;
+        uint256 doctorId;
         uint256 randomNumberId;
-        uint256 healthyVillagerId;
+        uint256 healthyDoctorId;
         uint256 randomNumberSliceOffset;
 
         while (madeSick < _toMakeSick) {
-            // Slices the random number to get the random villager that will be infected
-            healthyVillagerId =
-                _sliceRandomNumber(_randomNumbers[randomNumberId], randomNumberSliceOffset++) % _healthyVillagersNumber;
-            villagerId = healthyVillagers.at(healthyVillagerId);
+            // Slices the random number to get the random doctor that will be infected
+            healthyDoctorId =
+                _sliceRandomNumber(_randomNumbers[randomNumberId], randomNumberSliceOffset++) % _healthyDoctorsNumber;
+            doctorId = healthyDoctors.at(healthyDoctorId);
 
-            // Removing the villagers from the healthy villagers list and infecting him
-            healthyVillagers.remove(villagerId);
-            villagerStatus[villagerId] = Status.Infected;
+            // Removing the doctors from the healthy doctors list and infecting him
+            healthyDoctors.remove(doctorId);
+            doctorStatus[doctorId] = Status.Infected;
 
-            --_healthyVillagersNumber;
+            --_healthyDoctorsNumber;
             ++madeSick;
 
             // IF the random number has been used 8 times, we get a new one
@@ -354,7 +349,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
                 ++randomNumberId;
             }
 
-            emit Sick(villagerId);
+            emit Sick(doctorId);
         }
     }
 
@@ -378,7 +373,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     }
 
     /// @dev Random numbers will be sliced into uint32s to reduce the amount of random numbers needed
-    /// Since the array to select the random villager will be at most 1k, uint32 numbers are enough
+    /// Since the array to select the random doctor will be at most 1k, uint32 numbers are enough
     /// to get sufficiently random numbers
     function _requestRandomWords() private {
         // Extra safety check, but that shouldn't happen
@@ -386,7 +381,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
             revert VRFRequestAlreadyAsked();
         }
 
-        uint256 infectedDoctors = healthyVillagers.length() * infectionPercentagePerRound[currentEpoch] / BASIS_POINT;
+        uint256 infectedDoctors = healthyDoctors.length() * infectionPercentagePerEpoch[currentEpoch] / BASIS_POINT;
         infectedDoctorsPerEpoch[currentEpoch + 1] = infectedDoctors;
         uint32 wordsNumber = uint32(infectedDoctors / 8 + 1);
 

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -44,10 +44,9 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
 
     /// @dev Different statuses a doctor can have
     enum Status {
-        Unknown,
+        Dead,
         Healthy,
-        Infected,
-        Dead
+        Infected
     }
 
     /// @notice Address of the doctor collection contract
@@ -218,7 +217,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     }
 
     /// @notice Starts a new epoch if the conditions are met
-    function startEpoch() public gameOn {
+    function startEpoch() external gameOn {
         ++currentEpoch;
 
         uint256[] memory randomNumbers = epochVRFNumber[epochVRFRequest[currentEpoch]];

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -19,8 +19,8 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
     uint256 public immutable override playerNumberToEndGame;
     /// @notice Percentage of doctors that will be infected each epoch
     uint256[] public override infectionPercentagePerEpoch;
-    /// @notice Total number of epochs
-    uint256 private immutable totalDefinedEpochNumber;
+    /// @notice Total number of epochs with a defined infection percentage. If the game lasts longer, the last percentage defined will be used
+    uint256 public immutable override totalDefinedEpochNumber;
     /// @dev Number of doctors in the collection
     uint256 private immutable doctorNumber;
 

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -35,8 +35,10 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
     event DoctorsInfectedThisEpoch(uint256 indexed epoch, uint256 infectedDoctors);
     event DoctorsDeadThisEpoch(uint256 indexed epoch, uint256 deadDoctors);
     event GameOver();
+    event PrizeWithdrawalAllowed(bool newValue);
     event PrizeWithdrawn(uint256 indexed doctorId, uint256 prize);
     event PrizePotIncreased(uint256 amount);
+    event FundsEmergencyWithdraw(uint256 amount);
 
     /// Individual events
     event Sick(uint256 indexed doctorId);
@@ -199,6 +201,8 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
         }
 
         prizeWithdrawalAllowed = _status;
+
+        emit PrizeWithdrawalAllowed(_status);
     }
 
     /// @notice Starts the game
@@ -324,6 +328,8 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
         if (!success) {
             revert FundsTransferFailed();
         }
+
+        emit FundsEmergencyWithdraw(address(this).balance);
     }
 
     /// @dev Send AVAX to the contract to increase the prize pot

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -253,6 +253,10 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
     /// @param _doctorId ID of the doctor to cure
     /// @param _potionId ID of the potion to use
     function drinkPotion(uint256 _doctorId, uint256 _potionId) external override {
+        if (block.timestamp > epochStartTime + epochDuration) {
+            revert EpochAlreadyEnded();
+        }
+
         if (doctorStatus[_doctorId] != Status.Infected) {
             revert DoctorNotInfected();
         }

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -27,7 +27,7 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
     /// @notice Current epoch. Epoch is incremented at the beginning of each epoch
     uint256 public override currentEpoch;
     /// @notice Duration of each epoch in seconds
-    uint256 public override epochDuration;
+    uint256 public immutable override epochDuration;
     /// @notice Start time of the latest epoch
     uint256 public override epochStartTime;
 
@@ -62,11 +62,11 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
     /// @dev Address of the VRF coordinator
     VRFCoordinatorV2Interface private immutable vrfCoordinator;
     /// @dev VRF subscription ID
-    uint64 private subscriptionId;
+    uint64 private immutable subscriptionId;
     /// @dev VRF key hash
-    bytes32 private keyHash;
+    bytes32 private immutable keyHash;
     /// @dev Max gas used on the VRF callback
-    uint32 private maxGas;
+    uint32 private immutable maxGas;
 
     /// @dev Basis point to calulate percentages
     uint256 private constant BASIS_POINT = 10_000;

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -31,7 +31,7 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
     /// Game events
     event GameStarted();
     event RandomWordsFulfilled(uint256 epoch, uint256 requestId);
-    event DoctorsInfectedThisEpoch(uint256 indexed epoch, uint256 deadDoctors);
+    event DoctorsInfectedThisEpoch(uint256 indexed epoch, uint256 infectedDoctors);
     event DoctorsDeadThisEpoch(uint256 indexed epoch, uint256 deadDoctors);
     event GameOver();
     event PrizeWithdrawn(uint256 indexed doctorId, uint256 prize);
@@ -89,7 +89,7 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
     /// @notice True is the game is over
     bool public isGameOver;
     /// @notice True is the game started
-    bool public gameStarted;
+    bool public isGameStarted;
     /// @notice Prize pot that will be distributed to the winners at the end of the game
     uint256 public prizePot;
     /// @notice States if the withdrawal is open. Set by the contract owner
@@ -108,7 +108,7 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
     uint256 private constant BASIS_POINT = 10_000;
 
     modifier gameOn() {
-        if (isGameOver || !gameStarted) {
+        if (isGameOver || !isGameStarted) {
             revert GameIsClosed();
         }
         _;
@@ -200,7 +200,7 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
 
     /// @notice Starts the game
     function startGame() external onlyOwner {
-        if (gameStarted) {
+        if (isGameStarted) {
             revert GameAlreadyStarted();
         }
 
@@ -208,7 +208,7 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
             revert GameNotStarted();
         }
 
-        gameStarted = true;
+        isGameStarted = true;
         emit GameStarted();
 
         _requestRandomWords();

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -72,8 +72,10 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
     /// @notice Status of the doctors
     mapping(uint256 => Status) public doctorStatus;
 
-    /// @notice Stores the number of doctors infected each epoch
+    /// @notice Stores the number of doctors infected each epoch. This is purely for the front-end
     mapping(uint256 => uint256) public infectedDoctorsPerEpoch;
+    /// @notice Stores the number of dead doctors each epoch. This is purely for the front-end
+    mapping(uint256 => uint256) public deadDoctorsPerEpoch;
     /// @notice VRF request IDs for each epoch
     mapping(uint256 => uint256) public epochVRFRequest;
     /// @notice VRF response for each epoch
@@ -254,6 +256,7 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
             }
         }
 
+        deadDoctorsPerEpoch[currentEpoch] = deads;
         emit DoctorsDeadThisEpoch(currentEpoch, deads);
 
         if (healthyDoctors.length() <= playerNumberToEndGame || currentEpoch == totalEpochNumber) {

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -99,6 +99,14 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
         bytes32 _keyHash,
         uint32 _maxGas
     ) VRFConsumerBaseV2(address(_vrfCoordinator)) {
+        if (_playerNumberToEndGame == 0) {
+            revert InvalidPlayerNumberToEndGame();
+        }
+
+        if (_epochDuration == 0 || _epochDuration > 7 days) {
+            revert InvalidEpochDuration();
+        }
+
         for (uint256 i = 0; i < _infectionPercentagePerEpoch.length; i++) {
             if (_infectionPercentagePerEpoch[i] > BASIS_POINT) {
                 revert InvalidInfectionPercentage();

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -347,19 +347,21 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
 
     /// @dev Get one random number that will be shuffled as many times as needed to infect n random doctors
     function _requestRandomWords() private {
+        uint256 nextEpochCached = currentEpoch + 1;
         // Extra safety check, but that shouldn't happen
-        if (epochVRFNumber[epochVRFRequest[currentEpoch + 1]] != 0) {
+        if (epochVRFNumber[epochVRFRequest[nextEpochCached]] != 0) {
             revert VRFRequestAlreadyAsked();
         }
 
-        epochVRFRequest[currentEpoch + 1] = vrfCoordinator.requestRandomWords(keyHash, subscriptionId, 3, maxGas, 1);
+        epochVRFRequest[nextEpochCached] = vrfCoordinator.requestRandomWords(keyHash, subscriptionId, 3, maxGas, 1);
     }
 
     /// @dev Callback function used by VRF Coordinator
     /// @param _requestId Request ID
     /// @param _randomWords Random numbers provided by VRF
     function fulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) internal override {
-        uint256 epochVRFRequestCached = epochVRFRequest[currentEpoch + 1];
+        uint256 nextEpochCached = currentEpoch + 1;
+        uint256 epochVRFRequestCached = epochVRFRequest[nextEpochCached];
         if (_requestId != epochVRFRequestCached) {
             revert InvalidRequestId();
         }
@@ -370,6 +372,6 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
 
         epochVRFNumber[_requestId] = _randomWords[0];
 
-        emit RandomWordsFulfilled(currentEpoch + 1, _requestId);
+        emit RandomWordsFulfilled(nextEpochCached, _requestId);
     }
 }

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -256,7 +256,7 @@ contract PlagueGame is Ownable, VRFConsumerBaseV2 {
 
         emit DoctorsDeadThisEpoch(currentEpoch, deads);
 
-        if (healthyDoctors.length() <= 10 || currentEpoch == 12) {
+        if (healthyDoctors.length() <= playerNumberToEndGame || currentEpoch == totalEpochNumber) {
             isGameOver = true;
             emit GameOver();
             return;

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -7,8 +7,6 @@ import "openzeppelin/token/ERC721//extensions/IERC721Enumerable.sol";
 import "chainlink/VRFConsumerBaseV2.sol";
 import "chainlink/interfaces/VRFCoordinatorV2Interface.sol";
 
-import "forge-std/console.sol";
-
 contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     event Sick(uint256 indexed villagerId);
     event Cured(uint256 indexed villagerId);
@@ -35,11 +33,11 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     mapping(uint256 => uint256) public epochVRFRequest;
     mapping(uint256 => uint256[]) public epochVRFNumber;
     mapping(uint256 => bool) public epochStarted;
+    mapping(uint256 => bool) public epochEnded;
 
     bool public isGameOver;
-    bool public canWithdraw;
+    bool public gameStarted;
     uint256 public prizePot;
-    // mapping(uint256 => uint256) public infectionPercentagePerRound;
 
     uint256[] public infectionPercentagePerRound;
     uint256 public immutable totalRoundNumber;
@@ -47,14 +45,23 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
 
     uint256 public currentEpoch;
     bool public epochLocked;
+    uint256 public epochDuration;
+    uint256 public epochStartTime;
 
     EnumerableSet.UintSet healthyVillagers;
 
+    mapping(uint256 => bool) withdrewPrize;
+
     uint256 private immutable villagerNumber;
-    uint256 public lastVillagerUpdated;
+
+    bool prizeWithdrawalAllowed;
+
+    uint64 subscriptionId;
+    bytes32 keyHash;
+    uint32 maxGas;
 
     modifier gameOn() {
-        if (isGameOver) {
+        if (isGameOver || !gameStarted) {
             revert("game over");
         }
         _;
@@ -65,43 +72,82 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         IERC721Enumerable _potions,
         uint256[] memory _rounds,
         uint256 _playerNumberToEndGame,
-        VRFCoordinatorV2Interface _vrfCoordinator
+        uint256 _epochDuration,
+        VRFCoordinatorV2Interface _vrfCoordinator,
+        uint64 _subscriptionId,
+        bytes32 _keyHash,
+        uint32 _maxGas
     ) VRFConsumerBaseV2(address(_vrfCoordinator)) {
         villagers = _villagers;
         vrfCoordinator = _vrfCoordinator;
         villagerNumber = _villagers.totalSupply();
         playerNumberToEndGame = _playerNumberToEndGame;
 
-        for (uint256 i = 0; i < villagerNumber; i++) {
-            healthyVillagers.add(i);
-            villagerStatus[i] = Status.Healthy;
-        }
-
-        if (villagerNumber > 1000) {
-            revert();
+        if (villagerNumber > 2000) {
+            revert("Collection too big");
         }
 
         for (uint256 i = 0; i < _rounds.length; i++) {
             if (_rounds[i] > BASIS_POINT) {
-                revert();
+                revert("Invalid infection percentage");
             }
         }
 
         potions = _potions;
         infectionPercentagePerRound = _rounds;
         totalRoundNumber = _rounds.length;
+        epochDuration = _epochDuration;
+
+        subscriptionId = _subscriptionId;
+        keyHash = _keyHash;
+        maxGas = _maxGas;
     }
 
     function getHealthyVillagersNumber() external view returns (uint256 healthyVillagersNumber) {
         healthyVillagersNumber = healthyVillagers.length();
     }
 
+    function initializeGame(uint256 _amount) external {
+        uint256 lastVillagerUpdated = healthyVillagers.length();
+
+        if (lastVillagerUpdated + _amount > villagerNumber) {
+            revert("Too many doctors intialized");
+        }
+
+        uint256 lastIndex = lastVillagerUpdated + _amount;
+        for (uint256 i = lastVillagerUpdated; i < lastIndex; i++) {
+            villagerStatus[i] = Status.Healthy;
+            healthyVillagers.add(i);
+        }
+    }
+
+    function allowPrizeWithdraw(bool _status) external onlyOwner {
+        if (_status == prizeWithdrawalAllowed) {
+            revert("Prize withdrawal not allowed");
+        }
+
+        if (!isGameOver) {
+            revert("Game not over");
+        }
+
+        prizeWithdrawalAllowed = _status;
+    }
+
     function startGame() external onlyOwner {
-        ++currentEpoch;
+        if (healthyVillagers.length() < villagerNumber) {
+            revert("Game not ready");
+        }
+
+        if (gameStarted) {
+            revert("Game already started");
+        }
+
+        gameStarted = true;
         _requestRandomWords();
     }
 
     function startEpoch() public gameOn {
+        ++currentEpoch;
         uint256[] memory randomNumbers = epochVRFNumber[epochVRFRequest[currentEpoch]];
 
         if (randomNumbers.length == 0) {
@@ -113,18 +159,31 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         }
 
         epochStarted[currentEpoch] = true;
+        epochStartTime = block.timestamp;
 
         uint256 healthyVillagersNumber = healthyVillagers.length();
-        uint256 toMakeSick = healthyVillagersNumber * infectionPercentagePerRound[currentEpoch] / BASIS_POINT;
+        uint256 toMakeSick = healthyVillagersNumber * infectionPercentagePerRound[currentEpoch - 1] / BASIS_POINT;
 
         _infectRandomVillagers(healthyVillagersNumber, toMakeSick, randomNumbers);
     }
 
     function endEpoch() external gameOn {
-        for (uint256 i = 0; i < villagerNumber; i++) {
+        if (block.timestamp < epochStartTime + epochDuration) {
+            revert("epoch not ended");
+        }
+
+        if (epochEnded[currentEpoch] == true) {
+            revert("epoch already ended");
+        }
+
+        epochEnded[currentEpoch] = true;
+
+        uint256 dead;
+        for (uint256 i = 0; i < villagerNumber; ++i) {
             if (villagerStatus[i] == Status.Infected) {
                 villagerStatus[i] = Status.Dead;
                 // emit Dead(i);
+                ++dead;
             }
         }
 
@@ -133,7 +192,6 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
             return;
         }
 
-        ++currentEpoch;
         _requestRandomWords();
     }
 
@@ -150,6 +208,33 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         // emit Cured(_villagerId);
     }
 
+    function withdrawPrize(uint256 _villagerId) external {
+        if (!prizeWithdrawalAllowed) {
+            revert("withdrawal not open");
+        }
+
+        if (
+            villagerStatus[_villagerId] != Status.Healthy || villagers.ownerOf(_villagerId) != msg.sender
+                || withdrewPrize[_villagerId]
+        ) {
+            revert("not owner or not healthy");
+        }
+
+        withdrewPrize[_villagerId] = true;
+
+        uint256 prize = prizePot / healthyVillagers.length();
+
+        (bool succes,) = payable(msg.sender).call{value: prize}("");
+
+        if (!succes) {
+            revert("transfer failed");
+        }
+    }
+
+    receive() external payable {
+        prizePot += msg.value;
+    }
+
     // Loops through the healthy villagers and infects them
     // until the number of infected villagers is equal to the
     // requested number
@@ -160,28 +245,27 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     ) private {
         uint256 madeSick;
         uint256 villagerId;
-        uint256 randomNumber;
         uint256 randomNumberId;
         uint256 healthyVillagerId;
         uint256 randomNumberSliceOffset;
 
         while (madeSick < _toMakeSick) {
-            randomNumber = _randomNumbers[randomNumberId];
             healthyVillagerId =
                 _sliceRandomNumber(_randomNumbers[randomNumberId], randomNumberSliceOffset++) % _healthyVillagersNumber;
             villagerId = healthyVillagers.at(healthyVillagerId);
 
             healthyVillagers.remove(villagerId);
+
             villagerStatus[villagerId] = Status.Infected;
-            --_healthyVillagersNumber;
+
             // emit Sick(villagerId);
 
+            --_healthyVillagersNumber;
             ++madeSick;
+
             if (randomNumberSliceOffset == 8) {
                 randomNumberSliceOffset = 0;
                 ++randomNumberId;
-            } else {
-                ++randomNumberSliceOffset;
             }
         }
     }
@@ -204,26 +288,29 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
     // Since the array to select the random villager will be at most 1k, uint32 numbers are enough
     // to get sufficiently random numbers
     function _requestRandomWords() private {
-        if (epochVRFNumber[epochVRFRequest[currentEpoch]].length != 0) {
+        if (epochVRFNumber[epochVRFRequest[currentEpoch + 1]].length != 0) {
             revert("request locked");
         }
+
         uint256 infectedDoctors = healthyVillagers.length() * infectionPercentagePerRound[currentEpoch] / BASIS_POINT;
-        infectedDoctorsPerEpoch[currentEpoch] = infectedDoctors;
+        infectedDoctorsPerEpoch[currentEpoch + 1] = infectedDoctors;
         uint32 wordsNumber = uint32(infectedDoctors / 8 + 1);
 
-        epochVRFRequest[currentEpoch] = vrfCoordinator.requestRandomWords("", 1, 5, 800_000, wordsNumber);
+        epochVRFRequest[currentEpoch + 1] =
+            vrfCoordinator.requestRandomWords(keyHash, subscriptionId, 3, maxGas, wordsNumber);
     }
 
     function fulfillRandomWords(uint256 requestId, uint256[] memory randomWords) internal override {
-        // Checks if this is the correct request
-        if (requestId != epochVRFRequest[currentEpoch]) {
+        if (requestId != epochVRFRequest[currentEpoch + 1]) {
             revert("wrong request");
+        }
+
+        if (epochVRFNumber[epochVRFRequest[currentEpoch + 1]].length != 0) {
+            revert("request locked");
         }
 
         epochVRFNumber[requestId] = randomWords;
 
-        emit RandomWordsFulfilled(currentEpoch, requestId);
-
-        // startEpoch();
+        emit RandomWordsFulfilled(currentEpoch + 1, requestId);
     }
 }

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -13,7 +13,7 @@ error CollectionTooBig();
 error GameAlreadyStarted();
 error GameNotStarted();
 error GameNotOver();
-error GameIsOver();
+error GameIsClosed();
 error EpochNotReadyToEnd();
 error EpochAlreadyEnded();
 error DoctorNotInfected();
@@ -26,13 +26,18 @@ error WithdrawalClosed();
 error FundsTransferFailed();
 
 contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
-    event Sick(uint256 indexed villagerId);
-    event Cured(uint256 indexed villagerId);
-    event Dead(uint256 indexed villagerId);
-    event RandomWordsFulfilled(uint256 epoch, uint256 requestId);
-
     using EnumerableSet for EnumerableSet.UintSet;
 
+    /// @dev Event emitted when a doctor is infected
+    event Sick(uint256 indexed villagerId);
+    /// @dev Event emitted when a doctor is cured
+    event Cured(uint256 indexed villagerId);
+    /// @dev Event emitted when a doctor is dead
+    event Dead(uint256 indexed villagerId);
+    /// @dev Event emitted when the VRF response is received
+    event RandomWordsFulfilled(uint256 epoch, uint256 requestId);
+
+    /// @dev Different statuses a doctor can have
     enum Status {
         Unknown,
         Healthy,
@@ -40,55 +45,87 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         Dead
     }
 
+    /// @notice Address of the doctor collection contract
     IERC721Enumerable public immutable villagers;
+    /// @notice Address of the potion collection contract
     IERC721Enumerable public immutable potions;
-    VRFCoordinatorV2Interface private immutable vrfCoordinator;
+    /// @notice Number of doctors still alive triggering the end of the game
     uint256 public immutable playerNumberToEndGame;
-
-    uint256 private constant BASIS_POINT = 10_000;
-
-    mapping(uint256 => Status) public villagerStatus;
-    mapping(uint256 => uint256) public epochVRFRequest;
-    mapping(uint256 => uint256[]) public epochVRFNumber;
-    mapping(uint256 => bool) public epochStarted;
-    mapping(uint256 => bool) public epochEnded;
-
-    bool public isGameOver;
-    bool public gameStarted;
-    uint256 public prizePot;
-
+    /// @notice Percentage of doctors that will  be infected each epoch
     uint256[] public infectionPercentagePerRound;
+    /// @notice Total number of epochs
     uint256 public immutable totalRoundNumber;
-    mapping(uint256 => uint256) public infectedDoctorsPerEpoch;
-
-    uint256 public currentEpoch;
-    bool public epochLocked;
-    uint256 public epochDuration;
-    uint256 public epochStartTime;
-
-    EnumerableSet.UintSet healthyVillagers;
-
-    mapping(uint256 => bool) withdrewPrize;
-
+    /// @dev Number of doctors in the collection
     uint256 private immutable villagerNumber;
 
+    /// @notice Current epoch. Epoch is incremented at the beginning of each round
+    uint256 public currentEpoch;
+    /// @notice Duration of each epoch in seconds
+    uint256 public epochDuration;
+    /// @notice Start time of the latest epoch
+    uint256 public epochStartTime;
+
+    /// @notice Status of the villagers
+    mapping(uint256 => Status) public villagerStatus;
+
+    /// @notice Stores the number of doctors infect each round
+    mapping(uint256 => uint256) public infectedDoctorsPerEpoch;
+    /// @notice VRF request IDs for each epoch
+    mapping(uint256 => uint256) public epochVRFRequest;
+    /// @notice VRF response for each epoch
+    mapping(uint256 => uint256[]) public epochVRFNumber;
+    /// @notice Stores if a user already claimed his prize for a doctors he owns
+    mapping(uint256 => bool) public withdrewPrize;
+    /// @dev Stores if an epoch has started
+    mapping(uint256 => bool) private epochStarted;
+    /// @dev Stores if an epoch has started
+    mapping(uint256 => bool) private epochEnded;
+
+    /// @dev List of healthy villagers
+    EnumerableSet.UintSet private healthyVillagers;
+
+    /// @notice True is the game is over
+    bool public isGameOver;
+    /// @notice True is the game started
+    bool public gameStarted;
+    /// @notice Prize pot that will be distributed to the winners at the end of the game
+    uint256 public prizePot;
+    /// @notice States if the withdrawal is open. Set by the contract owner
     bool public prizeWithdrawalAllowed;
 
-    uint64 subscriptionId;
-    bytes32 keyHash;
-    uint32 maxGas;
+    /// @dev Address of the VRF coordinator
+    VRFCoordinatorV2Interface private immutable vrfCoordinator;
+    /// @dev VRF subscription ID
+    uint64 private subscriptionId;
+    /// @dev VRF key hash
+    bytes32 private keyHash;
+    /// @dev Max gas used on the VRF callback
+    uint32 private maxGas;
+
+    /// @dev Basis point to calulate percentages
+    uint256 private constant BASIS_POINT = 10_000;
 
     modifier gameOn() {
         if (isGameOver || !gameStarted) {
-            revert GameIsOver();
+            revert GameIsClosed();
         }
         _;
     }
 
+    /// @dev Constructor
+    /// @param _villagers Address of the doctor collection contract
+    /// @param _potions Address of the potion collection contract
+    /// @param _infectionPercentagePerRound Percentage of doctors that will  be infected each epoch
+    /// @param _playerNumberToEndGame Number of doctors still alive triggering the end of the game
+    /// @param _epochDuration Duration of each epoch in seconds
+    /// @param _vrfCoordinator Address of the VRF coordinator
+    /// @param _subscriptionId VRF subscription ID
+    /// @param _keyHash VRF key hash
+    /// @param _maxGas Max gas used on the VRF callback
     constructor(
         IERC721Enumerable _villagers,
         IERC721Enumerable _potions,
-        uint256[] memory _rounds,
+        uint256[] memory _infectionPercentagePerRound,
         uint256 _playerNumberToEndGame,
         uint256 _epochDuration,
         VRFCoordinatorV2Interface _vrfCoordinator,
@@ -96,35 +133,41 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         bytes32 _keyHash,
         uint32 _maxGas
     ) VRFConsumerBaseV2(address(_vrfCoordinator)) {
+        for (uint256 i = 0; i < _infectionPercentagePerRound.length; i++) {
+            if (_infectionPercentagePerRound[i] > BASIS_POINT) {
+                revert InvalidInfectionPercentage();
+            }
+        }
+
         villagers = _villagers;
         vrfCoordinator = _vrfCoordinator;
         villagerNumber = _villagers.totalSupply();
-        playerNumberToEndGame = _playerNumberToEndGame;
 
         if (villagerNumber > 2000) {
             revert CollectionTooBig();
         }
 
-        for (uint256 i = 0; i < _rounds.length; i++) {
-            if (_rounds[i] > BASIS_POINT) {
-                revert InvalidInfectionPercentage();
-            }
-        }
-
+        playerNumberToEndGame = _playerNumberToEndGame;
         potions = _potions;
-        infectionPercentagePerRound = _rounds;
-        totalRoundNumber = _rounds.length;
+        infectionPercentagePerRound = _infectionPercentagePerRound;
+        totalRoundNumber = _infectionPercentagePerRound.length;
         epochDuration = _epochDuration;
 
+        // VRF setup
         subscriptionId = _subscriptionId;
         keyHash = _keyHash;
         maxGas = _maxGas;
     }
 
+    /// @notice Gets the number of healthy doctors
+    /// @return healthyVillagersNumber Number of healthy doctors
     function getHealthyVillagersNumber() external view returns (uint256 healthyVillagersNumber) {
         healthyVillagersNumber = healthyVillagers.length();
     }
 
+    /// @notice Initializes the game
+    /// @dev This function is very expensive is gas, that's why it needs to be called several times
+    /// @param _amount Amount of doctors to initialize
     function initializeGame(uint256 _amount) external {
         uint256 lastVillagerUpdated = healthyVillagers.length();
 
@@ -139,6 +182,8 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         }
     }
 
+    /// @notice Starts and pauses the prize withdrawal
+    /// @param _status True to allow the withdrawal of the prize
     function allowPrizeWithdraw(bool _status) external onlyOwner {
         if (!isGameOver) {
             revert GameNotOver();
@@ -151,6 +196,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         prizeWithdrawalAllowed = _status;
     }
 
+    /// @notice Starts the game
     function startGame() external onlyOwner {
         if (gameStarted) {
             revert GameAlreadyStarted();
@@ -164,6 +210,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         _requestRandomWords();
     }
 
+    /// @notice Starts a new epoch if the conditions are met
     function startEpoch() public gameOn {
         uint256[] memory randomNumbers = epochVRFNumber[epochVRFRequest[currentEpoch + 1]];
         if (randomNumbers.length == 0) {
@@ -181,6 +228,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         _infectRandomVillagers(healthyVillagersNumber, toMakeSick, randomNumbers);
     }
 
+    /// @notice Ends the current epoch if the condition are met
     function endEpoch() external gameOn {
         if (block.timestamp < epochStartTime + epochDuration) {
             revert EpochNotReadyToEnd();
@@ -209,6 +257,10 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         _requestRandomWords();
     }
 
+    /// @notice Burns a potion to cure a doctor
+    /// @dev User needs to have given approval to the contract
+    /// @param _villagerId ID of the doctor to cure
+    /// @param _potionId ID of the potion to use
     function drinkPotion(uint256 _villagerId, uint256 _potionId) external {
         if (villagerStatus[_villagerId] != Status.Infected) {
             revert DoctorNotInfected();
@@ -219,9 +271,11 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
 
         _burnPotion(_potionId);
 
-        // emit Cured(_villagerId);
+        emit Cured(_villagerId);
     }
 
+    /// @notice Withdraws the prize for a winning doctor
+    /// @param _villagerId ID of the doctor to withdraw the prize for
     function withdrawPrize(uint256 _villagerId) external {
         if (!prizeWithdrawalAllowed) {
             revert WithdrawalClosed();
@@ -245,13 +299,17 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         }
     }
 
+    /// @dev Send AVAX to the contract to increase the prize pot
     receive() external payable {
         prizePot += msg.value;
     }
 
-    // Loops through the healthy villagers and infects them
-    // until the number of infected villagers is equal to the
-    // requested number
+    /// @dev Loops through the healthy villagers and infects them
+    /// until the number of infected villagers is equal to the
+    /// requested number
+    /// @param _healthyVillagersNumber Number of healthy villagers
+    /// @param _toMakeSick Number of villagers to infect
+    /// @param _randomNumbers Random numbers provided by VRF to use to infect villagers
     function _infectRandomVillagers(
         uint256 _healthyVillagersNumber,
         uint256 _toMakeSick,
@@ -272,7 +330,7 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
 
             villagerStatus[villagerId] = Status.Infected;
 
-            // emit Sick(villagerId);
+            emit Sick(villagerId);
 
             --_healthyVillagersNumber;
             ++madeSick;
@@ -284,10 +342,15 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         }
     }
 
+    /// @dev Burns a potion NFT
+    /// @param _potionId ID of the NFT to burn
     function _burnPotion(uint256 _potionId) internal {
         potions.transferFrom(msg.sender, address(0xdead), _potionId);
     }
 
+    /// @dev Slices a UINT256 VRF random number to get a up to 8 uint32 random numbers
+    /// @param _randomNumber Random number to slice
+    /// @param _offset Offset of the slice
     function _sliceRandomNumber(uint256 _randomNumber, uint256 _offset)
         internal
         pure
@@ -298,9 +361,9 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
         }
     }
 
-    // Random numbers will be sliced into uint32 to reduce the amount of random numbers needed
-    // Since the array to select the random villager will be at most 1k, uint32 numbers are enough
-    // to get sufficiently random numbers
+    /// @dev Random numbers will be sliced into uint32s to reduce the amount of random numbers needed
+    /// Since the array to select the random villager will be at most 1k, uint32 numbers are enough
+    /// to get sufficiently random numbers
     function _requestRandomWords() private {
         // Extra safety check, but that shouldn't happen
         if (epochVRFNumber[epochVRFRequest[currentEpoch + 1]].length != 0) {
@@ -315,8 +378,11 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
             vrfCoordinator.requestRandomWords(keyHash, subscriptionId, 3, maxGas, wordsNumber);
     }
 
-    function fulfillRandomWords(uint256 requestId, uint256[] memory randomWords) internal override {
-        if (requestId != epochVRFRequest[currentEpoch + 1]) {
+    /// @dev Callback function used by VRF Coordinator
+    /// @param _requestId Request ID
+    /// @param _randomWords Random numbers provided by VRF
+    function fulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) internal override {
+        if (_requestId != epochVRFRequest[currentEpoch + 1]) {
             revert InvalidRequestId();
         }
 
@@ -324,8 +390,8 @@ contract PlagueGame is Ownable2Step, VRFConsumerBaseV2 {
             revert VRFRequestAlreadyAsked();
         }
 
-        epochVRFNumber[requestId] = randomWords;
+        epochVRFNumber[_requestId] = _randomWords;
 
-        emit RandomWordsFulfilled(currentEpoch + 1, requestId);
+        emit RandomWordsFulfilled(currentEpoch + 1, _requestId);
     }
 }

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import "src/PlagueGame.sol";
+import "./mocks/ERC721.sol";
+import "chainlink/mocks/VRFCoordinatorV2Mock.sol";
+
+contract PlagueGameTest is Test {
+    uint256 collectionSize = 1000;
+    uint256 roundNumber = 12;
+    uint256 playerNumberToEndGame = 10;
+    uint256[] public infectedDoctorsPerEpoch =
+        [2_000, 2_000, 2_000, 3_000, 3_000, 3_000, 4_000, 4_000, 4_000, 5_000, 5_000, 5_000];
+
+    PlagueGame plagueGame;
+    ERC721Mock villagers;
+    ERC721Mock potions;
+    VRFCoordinatorV2Mock coordinator;
+
+    uint256 s_nextRequestId = 1;
+    uint256 lastPotionUsed;
+    uint256 randomnessSeedIndex;
+
+    function setUp() public {
+        villagers = new ERC721Mock();
+        potions = new ERC721Mock();
+        coordinator = new VRFCoordinatorV2Mock(0,1);
+
+        for (uint256 i = 0; i < collectionSize; i++) {
+            villagers.mint();
+            potions.mint();
+        }
+
+        plagueGame = new PlagueGame(
+            villagers,
+            potions,
+            infectedDoctorsPerEpoch,
+            playerNumberToEndGame,
+            coordinator
+        );
+
+        // VRF setup
+        uint64 subId = coordinator.createSubscription();
+        coordinator.addConsumer(subId, address(plagueGame));
+        coordinator.fundSubscription(subId, 100e18);
+    }
+
+    function testGame() public {
+        assertEq(plagueGame.currentEpoch(), 0, "starting epoch should be 0");
+        assertEq(plagueGame.getHealthyVillagersNumber(), collectionSize, "all villagers should be healthy");
+
+        plagueGame.startGame();
+
+        coordinator.fulfillRandomWords(s_nextRequestId++, address(plagueGame));
+
+        assertEq(plagueGame.currentEpoch(), 1, "first epoch after starting game should be 1");
+
+        plagueGame.startEpoch();
+
+        assertEq(
+            collectionSize - plagueGame.getHealthyVillagersNumber(),
+            collectionSize * infectedDoctorsPerEpoch[0] / 10_000,
+            "20% of the villagers should be unhealthy"
+        );
+        assertEq(
+            plagueGame.infectedDoctorsPerEpoch(1),
+            collectionSize * infectedDoctorsPerEpoch[0] / 10_000,
+            "20% of the villagers should be infected"
+        );
+
+        plagueGame.endEpoch();
+    }
+
+    function testFullGame(uint256 _randomnessSeed) public {
+        plagueGame.startGame();
+        coordinator.fulfillRandomWords(s_nextRequestId++, address(plagueGame));
+
+        for (uint256 i = 0; i < roundNumber; i++) {
+            plagueGame.startEpoch();
+            _cureRandomDoctors(_randomnessSeed);
+            plagueGame.endEpoch();
+            if (i != roundNumber - 1 || plagueGame.getHealthyVillagersNumber() <= 10) {
+                break;
+            }
+            coordinator.fulfillRandomWords(s_nextRequestId++, address(plagueGame));
+        }
+    }
+
+    function _cureRandomDoctors(uint256 _randomnessSeed) private {
+        uint256 randomNumberOfDoctorsToCure =
+            _getRandomNumber(_randomnessSeed, plagueGame.infectedDoctorsPerEpoch(plagueGame.currentEpoch()));
+
+        _cureDoctors(randomNumberOfDoctorsToCure);
+    }
+
+    function _cureDoctors(uint256 _numberCured) private {
+        uint256 indexSearchForInfected;
+        for (uint256 i = 0; i < _numberCured; i++) {
+            if (lastPotionUsed < collectionSize) {
+                while (plagueGame.villagerStatus(indexSearchForInfected) != PlagueGame.Status.Infected) {
+                    ++indexSearchForInfected;
+                }
+
+                address owner = villagers.ownerOf(indexSearchForInfected);
+                potions.transferFrom(address(this), owner, lastPotionUsed);
+
+                vm.startPrank(owner);
+                potions.approve(address(plagueGame), lastPotionUsed);
+                plagueGame.drinkPotion(indexSearchForInfected, lastPotionUsed++);
+                vm.stopPrank();
+            }
+        }
+    }
+
+    function _getRandomNumber(uint256 _randomnessSeed, uint256 _bound) private returns (uint256 randomNumber) {
+        if (_bound != 0) {
+            randomNumber = uint256(keccak256(abi.encode(_randomnessSeed + randomnessSeedIndex++))) % _bound;
+        }
+    }
+}

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -11,7 +11,7 @@ error OnlyCoordinatorCanFulfill(address have, address want);
 
 contract PlagueGameTest is Test {
     // Collection configuration
-    uint256 collectionSize = 1000;
+    uint256 collectionSize = 1200;
     uint256 roundNumber = 12;
     uint256 playerNumberToEndGame = 10;
     uint256[] infectedDoctorsPerEpoch =
@@ -55,7 +55,6 @@ contract PlagueGameTest is Test {
         coordinator.fundSubscription(subscriptionId, lastSubscriptionBalance);
 
         _gameSetup();
-
         _initializeGame();
     }
 
@@ -191,10 +190,10 @@ contract PlagueGameTest is Test {
             plagueGame.endEpoch();
 
             if (i == roundNumber - 1) {
-                vm.expectRevert(GameIsOver.selector);
+                vm.expectRevert(GameIsClosed.selector);
                 plagueGame.endEpoch();
 
-                vm.expectRevert(GameIsOver.selector);
+                vm.expectRevert(GameIsClosed.selector);
                 plagueGame.startEpoch();
 
                 assertEq(plagueGame.isGameOver(), true, "game should be over");
@@ -228,7 +227,6 @@ contract PlagueGameTest is Test {
         uint256[] memory winners = _fetchDoctorsToStatus(PlagueGame.Status.Healthy);
 
         assertEq(winners.length, aliveDoctors, "The winners array should be the same size as the number of winners");
-        assertEq(aliveDoctors, 71, "We should have 71 winners");
         assertEq(prizePot, address(plagueGame).balance, "The prize pot should be equal to the contract balance");
 
         vm.expectRevert(WithdrawalClosed.selector);
@@ -280,7 +278,6 @@ contract PlagueGameTest is Test {
 
         uint256[] memory winners = _fetchDoctorsToStatus(PlagueGame.Status.Healthy);
 
-        // assertLe(winners.length, playerNumberToEndGame, "There should be no more then 10 winners");
         assertGt(winners.length, 0, "There should at least 1 winner");
     }
 
@@ -300,12 +297,8 @@ contract PlagueGameTest is Test {
                 }
 
                 _cureDoctor(indexSearchForInfected);
-
-                // console.log(lastPotionUsed);
             }
         }
-
-        // console.log("end round");
     }
 
     function _cureDoctor(uint256 _doctorId) private {
@@ -358,17 +351,6 @@ contract PlagueGameTest is Test {
         vm.expectRevert(TooManyInitialized.selector);
         plagueGame.initializeGame(collectionSize / 10);
     }
-
-    // function _loadWinners() private returns (uint256[] memory winners) {
-    //     for (uint256 i = 0; i < collectionSize; i++) {
-    //         if (plagueGame.villagerStatus(i) == PlagueGame.Status.Healthy) {
-    //             doctorsArray.push(i);
-    //         }
-    //     }
-
-    //     winners = doctorsArray;
-    //     doctorsArray = new uint256[](0);
-    // }
 
     function _gameSetup() private {
         plagueGame = new PlagueGame(

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -8,84 +8,224 @@ import "./mocks/ERC721.sol";
 import "chainlink/mocks/VRFCoordinatorV2Mock.sol";
 
 contract PlagueGameTest is Test {
+    // Collection configuration
     uint256 collectionSize = 1000;
     uint256 roundNumber = 12;
     uint256 playerNumberToEndGame = 10;
-    uint256[] public infectedDoctorsPerEpoch =
+    uint256[] infectedDoctorsPerEpoch =
         [2_000, 2_000, 2_000, 3_000, 3_000, 3_000, 4_000, 4_000, 4_000, 5_000, 5_000, 5_000];
+    uint256 epochDuration = 1 days;
+    uint256 prizePot = 100 ether;
+
+    // Test configuration
+    uint256[] curedDoctorsPerEpoch = [120, 110, 100, 90, 50, 40, 30, 20, 15, 10, 5, 2];
+
+    // VRF configuration
+    uint64 subscriptionId;
+    bytes32 keyHash = "";
+    uint32 maxGas = 1_500_000;
+    uint256 s_nextRequestId = 1;
+    uint96 lastSubscriptionBalance = 100 ether;
+
+    // Test variables
+    address BOB = address(0xb0b);
 
     PlagueGame plagueGame;
     ERC721Mock villagers;
     ERC721Mock potions;
     VRFCoordinatorV2Mock coordinator;
 
-    uint256 s_nextRequestId = 1;
     uint256 lastPotionUsed;
     uint256 randomnessSeedIndex;
+    uint256[] winnersArray;
 
     function setUp() public {
         villagers = new ERC721Mock();
         potions = new ERC721Mock();
         coordinator = new VRFCoordinatorV2Mock(0,1);
 
-        for (uint256 i = 0; i < collectionSize; i++) {
-            villagers.mint();
-            potions.mint();
-        }
+        villagers.mint(collectionSize);
+        potions.mint(collectionSize);
+
+        // VRF setup
+        subscriptionId = coordinator.createSubscription();
+        coordinator.fundSubscription(subscriptionId, lastSubscriptionBalance);
 
         plagueGame = new PlagueGame(
             villagers,
             potions,
             infectedDoctorsPerEpoch,
             playerNumberToEndGame,
-            coordinator
+            epochDuration,
+            coordinator,
+            subscriptionId,
+            keyHash,
+            maxGas
         );
 
-        // VRF setup
-        uint64 subId = coordinator.createSubscription();
-        coordinator.addConsumer(subId, address(plagueGame));
-        coordinator.fundSubscription(subId, 100e18);
+        _initializeGame();
+
+        coordinator.addConsumer(subscriptionId, address(plagueGame));
+        (bool success,) = payable(plagueGame).call{value: prizePot}("");
+        assert(success);
+    }
+
+    function testVRFSafeGuards() public {
+        plagueGame.startGame();
+        _mockVRFResponse();
+
+        vm.expectRevert();
+        _mockVRFResponse();
+        --s_nextRequestId;
+
+        plagueGame.startEpoch();
+        vm.expectRevert();
+        _mockVRFResponse();
+        --s_nextRequestId;
+
+        skip(epochDuration);
+        plagueGame.endEpoch();
+
+        vm.expectRevert();
+        coordinator.fulfillRandomWords(s_nextRequestId - 1, address(plagueGame));
+
+        _mockVRFResponse();
     }
 
     function testGame() public {
         assertEq(plagueGame.currentEpoch(), 0, "starting epoch should be 0");
         assertEq(plagueGame.getHealthyVillagersNumber(), collectionSize, "all villagers should be healthy");
+        assertEq(plagueGame.gameStarted(), false, "game should not be started");
+        assertEq(plagueGame.isGameOver(), false, "game should not be over");
 
         plagueGame.startGame();
+        _mockVRFResponse();
 
-        coordinator.fulfillRandomWords(s_nextRequestId++, address(plagueGame));
+        // Game can't be started twice
+        vm.expectRevert();
+        plagueGame.startGame();
 
-        assertEq(plagueGame.currentEpoch(), 1, "first epoch after starting game should be 1");
+        assertEq(plagueGame.gameStarted(), true, "game should be started");
 
-        plagueGame.startEpoch();
+        for (uint256 i = 0; i < roundNumber; ++i) {
+            uint256 healthyVillagersEndOfRound = plagueGame.getHealthyVillagersNumber();
+            uint256 deadVillagersEndOfRound = _fetchDoctorsToStatus(PlagueGame.Status.Dead);
 
-        assertEq(
-            collectionSize - plagueGame.getHealthyVillagersNumber(),
-            collectionSize * infectedDoctorsPerEpoch[0] / 10_000,
-            "20% of the villagers should be unhealthy"
-        );
-        assertEq(
-            plagueGame.infectedDoctorsPerEpoch(1),
-            collectionSize * infectedDoctorsPerEpoch[0] / 10_000,
-            "20% of the villagers should be infected"
-        );
+            plagueGame.startEpoch();
 
-        plagueGame.endEpoch();
+            assertEq(plagueGame.currentEpoch(), i + 1, "should be the correct epoch");
+
+            // Epoch can't be started twice
+            vm.expectRevert();
+            plagueGame.startEpoch();
+
+            uint256 expectedInfections = healthyVillagersEndOfRound * infectedDoctorsPerEpoch[i] / 10_000;
+            assertEq(
+                healthyVillagersEndOfRound - plagueGame.getHealthyVillagersNumber(),
+                expectedInfections,
+                "correct number of the villagers should have been removed from the healthy villagers set"
+            );
+            assertEq(
+                plagueGame.infectedDoctorsPerEpoch(i + 1),
+                expectedInfections,
+                "correct number of the villagers should be infected"
+            );
+            assertEq(
+                _fetchDoctorsToStatus(PlagueGame.Status.Infected),
+                expectedInfections,
+                "The expected number of villagers is infected"
+            );
+
+            uint256 doctorsToCure = curedDoctorsPerEpoch[i];
+            _cureDoctors(doctorsToCure);
+
+            assertEq(
+                healthyVillagersEndOfRound - plagueGame.getHealthyVillagersNumber(),
+                expectedInfections - doctorsToCure,
+                "Doctors should have been put back in the healthy villagers set"
+            );
+
+            assertEq(
+                _fetchDoctorsToStatus(PlagueGame.Status.Infected),
+                expectedInfections - doctorsToCure,
+                "The expected number of villagers is infected"
+            );
+
+            skip(epochDuration);
+            plagueGame.endEpoch();
+
+            // Epoch can't be ended twice
+            vm.expectRevert();
+            plagueGame.endEpoch();
+
+            if (i == roundNumber - 1) {
+                assertEq(plagueGame.isGameOver(), true, "game should be over");
+            } else {
+                assertEq(plagueGame.isGameOver(), false, "game should not be over");
+                _mockVRFResponse();
+            }
+
+            assertEq(
+                _fetchDoctorsToStatus(PlagueGame.Status.Dead) - deadVillagersEndOfRound,
+                expectedInfections - doctorsToCure,
+                "The expected number of villagers is dead"
+            );
+
+            assertEq(_fetchDoctorsToStatus(PlagueGame.Status.Infected), 0, "No more infected villagers");
+        }
+    }
+
+    function testPrizeWithdrawal() public {
+        testFullGame(0);
+        plagueGame.allowPrizeWithdraw(true);
+
+        uint256 aliveDoctors = plagueGame.getHealthyVillagersNumber();
+
+        uint256[] memory winners = _loadWinners();
+        assertEq(winners.length, aliveDoctors, "The winners array should be the same size as the number of winners");
+        assertEq(aliveDoctors, 71, "We should have 71 winners");
+
+        assertEq(prizePot, address(plagueGame).balance, "The prize pot should be equal to the contract balance");
+
+        uint256 prize = address(plagueGame).balance / aliveDoctors;
+
+        for (uint256 i = 0; i < winners.length; i++) {
+            uint256 winner = winners[i];
+
+            vm.prank(BOB);
+            vm.expectRevert();
+            plagueGame.withdrawPrize(winner);
+
+            uint256 balanceBefore = address(this).balance;
+            plagueGame.withdrawPrize(winner);
+            assertEq(address(this).balance, balanceBefore + prize, "The prize should have been withdrawn");
+
+            vm.expectRevert();
+            plagueGame.withdrawPrize(winner);
+        }
     }
 
     function testFullGame(uint256 _randomnessSeed) public {
         plagueGame.startGame();
-        coordinator.fulfillRandomWords(s_nextRequestId++, address(plagueGame));
+        _mockVRFResponse();
 
         for (uint256 i = 0; i < roundNumber; i++) {
             plagueGame.startEpoch();
             _cureRandomDoctors(_randomnessSeed);
+            skip(epochDuration);
             plagueGame.endEpoch();
-            if (i != roundNumber - 1 || plagueGame.getHealthyVillagersNumber() <= 10) {
+            if (plagueGame.getHealthyVillagersNumber() <= 10) {
                 break;
             }
-            coordinator.fulfillRandomWords(s_nextRequestId++, address(plagueGame));
+            if (i != roundNumber - 1) {
+                _mockVRFResponse();
+            }
         }
+
+        uint256[] memory winners = _loadWinners();
+
+        // assertLe(winners.length, playerNumberToEndGame, "There should be no more then 10 winners");
+        assertGt(winners.length, 0, "There should at least 1 winner");
     }
 
     function _cureRandomDoctors(uint256 _randomnessSeed) private {
@@ -98,7 +238,7 @@ contract PlagueGameTest is Test {
     function _cureDoctors(uint256 _numberCured) private {
         uint256 indexSearchForInfected;
         for (uint256 i = 0; i < _numberCured; i++) {
-            if (lastPotionUsed < collectionSize) {
+            if (lastPotionUsed < collectionSize * 8_000 / 10_000) {
                 while (plagueGame.villagerStatus(indexSearchForInfected) != PlagueGame.Status.Infected) {
                     ++indexSearchForInfected;
                 }
@@ -110,13 +250,58 @@ contract PlagueGameTest is Test {
                 potions.approve(address(plagueGame), lastPotionUsed);
                 plagueGame.drinkPotion(indexSearchForInfected, lastPotionUsed++);
                 vm.stopPrank();
+                // console.log(lastPotionUsed);
             }
         }
+
+        // console.log("end round");
     }
 
     function _getRandomNumber(uint256 _randomnessSeed, uint256 _bound) private returns (uint256 randomNumber) {
         if (_bound != 0) {
-            randomNumber = uint256(keccak256(abi.encode(_randomnessSeed + randomnessSeedIndex++))) % _bound;
+            randomNumber = uint256(keccak256(abi.encode(_randomnessSeed, randomnessSeedIndex++))) % _bound;
         }
     }
+
+    function _mockVRFResponse() private {
+        coordinator.fulfillRandomWords(s_nextRequestId++, address(plagueGame));
+        _checkVRFCost();
+    }
+
+    // Safety check to be sure we have a 50% margin on VRF requests for max gas used
+    function _checkVRFCost() private {
+        (uint96 vrfBalance,,,) = coordinator.getSubscription(subscriptionId);
+
+        assertLt(
+            (lastSubscriptionBalance - vrfBalance) * 15_000 / 10_000, maxGas, "Too much gas has been consumed by VRF"
+        );
+        lastSubscriptionBalance = vrfBalance;
+    }
+
+    function _fetchDoctorsToStatus(PlagueGame.Status _status) private view returns (uint256 doctors) {
+        for (uint256 i = 0; i < collectionSize; i++) {
+            if (plagueGame.villagerStatus(i) == _status) {
+                ++doctors;
+            }
+        }
+    }
+
+    function _initializeGame() private {
+        for (uint256 i = 0; i < 10; i++) {
+            plagueGame.initializeGame(collectionSize / 10);
+        }
+    }
+
+    function _loadWinners() private returns (uint256[] memory winners) {
+        for (uint256 i = 0; i < collectionSize; i++) {
+            if (plagueGame.villagerStatus(i) == PlagueGame.Status.Healthy) {
+                winnersArray.push(i);
+            }
+        }
+
+        winners = winnersArray;
+        winnersArray = new uint256[](0);
+    }
+
+    receive() external payable {}
 }

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -216,6 +216,12 @@ contract PlagueGameTest is Test {
                 "The expected number of doctors is dead"
             );
 
+            assertEq(
+                plagueGame.deadDoctorsPerEpoch(plagueGame.currentEpoch()),
+                expectedInfections - doctorsToCure,
+                "The expected number of doctors is dead"
+            );
+
             assertEq(_fetchDoctorsToStatus(PlagueGame.Status.Infected).length, 0, "No more infected doctors");
         }
     }

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "forge-std/Test.sol";
 
 import "src/PlagueGame.sol";
+import "src/IPlagueGame.sol";
 import "./mocks/ERC721.sol";
 import "chainlink/mocks/VRFCoordinatorV2Mock.sol";
 
@@ -129,7 +130,7 @@ contract PlagueGameTest is Test {
 
         for (uint256 i = 0; i < epochNumber; ++i) {
             uint256 healthyDoctorsEndOfEpoch = plagueGame.getHealthyDoctorsNumber();
-            uint256[] memory deadDoctorsEndOfEpoch = _fetchDoctorsToStatus(PlagueGame.Status.Dead);
+            uint256[] memory deadDoctorsEndOfEpoch = _fetchDoctorsToStatus(IPlagueGame.Status.Dead);
 
             plagueGame.startEpoch();
 
@@ -151,7 +152,7 @@ contract PlagueGameTest is Test {
                 "correct number of the doctors should be infected"
             );
             assertEq(
-                _fetchDoctorsToStatus(PlagueGame.Status.Infected).length,
+                _fetchDoctorsToStatus(IPlagueGame.Status.Infected).length,
                 expectedInfections,
                 "The expected number of doctors is infected"
             );
@@ -166,18 +167,18 @@ contract PlagueGameTest is Test {
             );
 
             assertEq(
-                _fetchDoctorsToStatus(PlagueGame.Status.Infected).length,
+                _fetchDoctorsToStatus(IPlagueGame.Status.Infected).length,
                 expectedInfections - doctorsToCure,
                 "The expected number of doctors is infected"
             );
 
-            uint256[] memory deadDoctors = _fetchDoctorsToStatus(PlagueGame.Status.Dead);
+            uint256[] memory deadDoctors = _fetchDoctorsToStatus(IPlagueGame.Status.Dead);
             for (uint256 j = 0; j < deadDoctors.length; j++) {
                 vm.expectRevert(DoctorNotInfected.selector);
                 plagueGame.drinkPotion(deadDoctors[j], lastPotionUsed);
             }
 
-            uint256[] memory healthyDoctors = _fetchDoctorsToStatus(PlagueGame.Status.Healthy);
+            uint256[] memory healthyDoctors = _fetchDoctorsToStatus(IPlagueGame.Status.Healthy);
             for (uint256 j = 0; j < healthyDoctors.length; j++) {
                 vm.expectRevert(DoctorNotInfected.selector);
                 plagueGame.drinkPotion(healthyDoctors[j], lastPotionUsed);
@@ -215,7 +216,7 @@ contract PlagueGameTest is Test {
             }
 
             assertEq(
-                _fetchDoctorsToStatus(PlagueGame.Status.Dead).length - deadDoctorsEndOfEpoch.length,
+                _fetchDoctorsToStatus(IPlagueGame.Status.Dead).length - deadDoctorsEndOfEpoch.length,
                 expectedInfections - doctorsToCure,
                 "The expected number of doctors is dead"
             );
@@ -226,7 +227,7 @@ contract PlagueGameTest is Test {
                 "The expected number of doctors is dead"
             );
 
-            assertEq(_fetchDoctorsToStatus(PlagueGame.Status.Infected).length, 0, "No more infected doctors");
+            assertEq(_fetchDoctorsToStatus(IPlagueGame.Status.Infected).length, 0, "No more infected doctors");
         }
     }
 
@@ -234,7 +235,7 @@ contract PlagueGameTest is Test {
         testFullGame(0);
 
         uint256 aliveDoctors = plagueGame.getHealthyDoctorsNumber();
-        uint256[] memory winners = _fetchDoctorsToStatus(PlagueGame.Status.Healthy);
+        uint256[] memory winners = _fetchDoctorsToStatus(IPlagueGame.Status.Healthy);
 
         assertEq(winners.length, aliveDoctors, "The winners array should be the same size as the number of winners");
         assertEq(prizePot, address(plagueGame).balance, "The prize pot should be equal to the contract balance");
@@ -285,7 +286,7 @@ contract PlagueGameTest is Test {
             _mockVRFResponse();
         }
 
-        uint256[] memory winners = _fetchDoctorsToStatus(PlagueGame.Status.Healthy);
+        uint256[] memory winners = _fetchDoctorsToStatus(IPlagueGame.Status.Healthy);
 
         assertGt(winners.length, 0, "There should at least 1 winner");
 
@@ -303,7 +304,7 @@ contract PlagueGameTest is Test {
         uint256 indexSearchForInfected;
         for (uint256 i = 0; i < _numberCured; i++) {
             if (lastPotionUsed < collectionSize * 8_000 / 10_000) {
-                while (plagueGame.doctorStatus(indexSearchForInfected) != PlagueGame.Status.Infected) {
+                while (plagueGame.doctorStatus(indexSearchForInfected) != IPlagueGame.Status.Infected) {
                     ++indexSearchForInfected;
                 }
 
@@ -343,7 +344,7 @@ contract PlagueGameTest is Test {
         lastSubscriptionBalance = vrfBalance;
     }
 
-    function _fetchDoctorsToStatus(PlagueGame.Status _status) private returns (uint256[] memory doctorsFromStatus) {
+    function _fetchDoctorsToStatus(IPlagueGame.Status _status) private returns (uint256[] memory doctorsFromStatus) {
         for (uint256 i = 0; i < collectionSize; i++) {
             if (plagueGame.doctorStatus(i) == _status) {
                 doctorsArray.push(i);

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -115,7 +115,7 @@ contract PlagueGameTest is Test {
     function testGame() public {
         assertEq(plagueGame.currentEpoch(), 0, "starting epoch should be 0");
         assertEq(plagueGame.getHealthyDoctorsNumber(), collectionSize, "all doctors should be healthy");
-        assertEq(plagueGame.gameStarted(), false, "game should not be started");
+        assertEq(plagueGame.isGameStarted(), false, "game should not be started");
         assertEq(plagueGame.isGameOver(), false, "game should not be over");
 
         plagueGame.startGame();
@@ -125,7 +125,7 @@ contract PlagueGameTest is Test {
 
         _mockVRFResponse();
 
-        assertEq(plagueGame.gameStarted(), true, "game should be started");
+        assertEq(plagueGame.isGameStarted(), true, "game should be started");
 
         for (uint256 i = 0; i < epochNumber; ++i) {
             uint256 healthyDoctorsEndOfEpoch = plagueGame.getHealthyDoctorsNumber();

--- a/test/mocks/ERC721.sol
+++ b/test/mocks/ERC721.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "openzeppelin/token/ERC721//extensions/ERC721Enumerable.sol";
+
+contract ERC721Mock is ERC721Enumerable {
+    constructor() ERC721("ERC721 Mock contract", "ERC721") {}
+
+    function mint() external {
+        _mint(msg.sender, totalSupply());
+    }
+}

--- a/test/mocks/ERC721.sol
+++ b/test/mocks/ERC721.sol
@@ -6,7 +6,9 @@ import "openzeppelin/token/ERC721//extensions/ERC721Enumerable.sol";
 contract ERC721Mock is ERC721Enumerable {
     constructor() ERC721("ERC721 Mock contract", "ERC721") {}
 
-    function mint() external {
-        _mint(msg.sender, totalSupply());
+    function mint(uint256 _number) external {
+        for (uint256 i = 0; i < _number; ++i) {
+            _mint(msg.sender, totalSupply());
+        }
     }
 }


### PR DESCRIPTION
### Contract for the plague game

_**First of all you should read the game specs that can be found [here](https://www.notion.so/traderjoexyz/Plague-Game-a95cfe84473142639487f5f0684bf210).**_

The basic flow of the game is:
1. `startEpoch` to use the random numbers to make doctors sick
2. Play the round and cure doctors
3. `endEpoch` to make the remaining infected doctors `dead` and then ask for VRF
4. VRF callback that allows the next round to start

A large amount of doctors needs to be randomly infected, so to reduce the cost of VRF I'm using each random number 8 times. It would be even smoother if the VRF callback could call `startEpoch` but the callback is limited to 2.5 million `wei` of gas.

Picking a random item in an array is pretty heavy in gas so I made these choices to make the game flow smooth:
- An array with the healthy doctors is initialized before the beginning of the game (that's very expensive and needs to be executed in a few steps)
- Doctors are removed from the array when infected at the start of the round. This is heavy in gas too but with the expected size of the collection, it doesn't go higher than 5 million `wei` at worst during the tests, which seems safe but I'm waiting for a bug fix on Foundry to make sure it doesn't go higher during the fuzzing tests.
- Doctors are put in the array again when cured

I also added a Github workflow to run foundry tests on PRs, hopefully it will work