### PR TITLE
Gas optimizations

### DIFF
--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -45,10 +45,8 @@ interface IPlagueGame {
     event PrizePotIncreased(uint256 amount);
     event FundsEmergencyWithdraw(uint256 amount);
 
-    /// Individual events
-    event Sick(uint256 indexed doctorId);
-    event Cured(uint256 indexed doctorId);
-    event Dead(uint256 indexed doctorId);
+    /// Doctor event
+    event DoctorCured(uint256 indexed doctorId, uint256 indexed potionId, uint256 indexed epoch);
 
     function doctors() external view returns (IERC721Enumerable);
     function potions() external view returns (IERC721Enumerable);
@@ -61,6 +59,7 @@ interface IPlagueGame {
     function epochDuration() external view returns (uint256);
     function epochStartTime() external view returns (uint256);
 
+    function healthyDoctorsNumber() external view returns (uint256);
     function doctorStatus(uint256 doctorId) external view returns (Status);
 
     function infectedDoctorsPerEpoch(uint256 epoch) external view returns (uint256);
@@ -74,6 +73,7 @@ interface IPlagueGame {
 
     function initializeGame(uint256 _amount) external;
     function allowPrizeWithdraw(bool _status) external;
+    function computeInfectedDoctors(uint256 _amount) external;
     function startGame() external;
     function startEpoch() external;
     function endEpoch() external;

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -70,7 +70,6 @@ interface IPlagueGame {
     function prizePot() external view returns (uint256);
     function prizeWithdrawalAllowed() external view returns (bool);
 
-    function getHealthyDoctorsNumber() external view returns (uint256);
     function initializeGame(uint256 _amount) external;
     function allowPrizeWithdraw(bool _status) external;
     function startGame() external;

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -12,6 +12,8 @@ error GameAlreadyStarted();
 error GameNotStarted();
 error GameNotOver();
 error GameIsClosed();
+error InfectionNotComputed();
+error NothingToCompute();
 error EpochNotReadyToEnd();
 error EpochAlreadyEnded();
 error DoctorNotInfected();

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -38,7 +38,7 @@ interface IPlagueGame {
     event GameStarted();
     event RandomWordsFulfilled(uint256 epoch, uint256 requestId);
     event DoctorsInfectedThisEpoch(uint256 indexed epoch, uint256 infectedDoctors);
-    event DoctorsDeadThisEpoch(uint256 indexed epoch, uint256 deadDoctors);
+    event EpochEnded(uint256 indexed epoch);
     event GameOver();
     event PrizeWithdrawalAllowed(bool newValue);
     event PrizeWithdrawn(uint256 indexed doctorId, uint256 prize);
@@ -64,7 +64,7 @@ interface IPlagueGame {
     function doctorStatus(uint256 doctorId) external view returns (Status);
 
     function infectedDoctorsPerEpoch(uint256 epoch) external view returns (uint256);
-    function deadDoctorsPerEpoch(uint256 epoch) external view returns (uint256);
+    function curedDoctorsPerEpoch(uint256 epoch) external view returns (uint256);
     function withdrewPrize(uint256 doctorId) external view returns (bool);
 
     function isGameOver() external view returns (bool);

--- a/src/IPlagueGame.sol
+++ b/src/IPlagueGame.sol
@@ -7,7 +7,7 @@ error InvalidPlayerNumberToEndGame();
 error InvalidInfectionPercentage();
 error InvalidEpochDuration();
 error TooManyInitialized();
-error CollectionTooBig();
+error InvalidCollection();
 error GameAlreadyStarted();
 error GameNotStarted();
 error GameNotOver();

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -117,7 +117,7 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
         vrfCoordinator = _vrfCoordinator;
         doctorNumber = _doctors.totalSupply();
 
-        if (doctorNumber > 1200) {
+        if (doctorNumber > 10_000) {
             revert CollectionTooBig();
         }
 

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -60,6 +60,8 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
     uint256 private constant HEALTHY_DOCTOR_SET_SIZE = 625;
     uint256[HEALTHY_DOCTOR_SET_SIZE] private _healthyDoctorsSet;
     uint256 private constant DOCTOR_ID_MASK = 0xFFFF;
+    uint256 private constant HEALTHY_DOCTOR_BASE_RANGE = 0xf000e000d000c000b000a0009000800070006000500040003000200010000;
+    uint256 private constant HEALTHY_DOCTOR_OFFSET = 0x10001000100010001000100010001000100010001000100010001000100010;
     /// @dev Array containing the status of every doctor
     /// A doctor status is stored in a 2 bits integer.
     // 256 / 2 = 128 doctors per slot
@@ -159,7 +161,7 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
         uint256 lastHealthyDoctorsSetItemUpdatedCached = _lastHealthyDoctorsSetItemUpdated;
         uint256 newlastHealthyDoctorsSetItemUpdated = lastHealthyDoctorsSetItemUpdatedCached + _amount;
 
-        if (newlastHealthyDoctorsSetItemUpdated > HEALTHY_DOCTOR_SET_SIZE) {
+        if (newlastHealthyDoctorsSetItemUpdated > (_doctorNumber + 15) / 16) {
             revert TooManyInitialized();
         }
 
@@ -174,17 +176,13 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
         }
 
         for (uint256 j = lastHealthyDoctorsSetItemUpdatedCached; j < newlastHealthyDoctorsSetItemUpdated; j++) {
-            uint256 doctorId;
-            for (uint256 k = 0; k < 16; ++k) {
-                doctorId += (k + 16 * j) << (k * 16);
-            }
-
-            _healthyDoctorsSet[j] = doctorId;
+            uint256 doctorIds = HEALTHY_DOCTOR_BASE_RANGE + HEALTHY_DOCTOR_OFFSET * j;
+            _healthyDoctorsSet[j] = doctorIds;
         }
 
         _lastHealthyDoctorsSetItemUpdated = newlastHealthyDoctorsSetItemUpdated;
 
-        if (newlastHealthyDoctorsSetItemUpdated == HEALTHY_DOCTOR_SET_SIZE) {
+        if (newlastHealthyDoctorsSetItemUpdated == (_doctorNumber + 15) / 16) {
             healthyDoctorsNumber = _doctorNumber;
         }
     }

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -136,8 +136,8 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
         _vrfCoordinator = vrfCoordinator_;
         _doctorNumber = _doctors.totalSupply();
 
-        if (_doctorNumber > 10_000) {
-            revert CollectionTooBig();
+        if (_doctorNumber > 10_000 || _doctorNumber == 0) {
+            revert InvalidCollection();
         }
 
         playerNumberToEndGame = _playerNumberToEndGame;

--- a/src/PlagueGame.sol
+++ b/src/PlagueGame.sol
@@ -161,9 +161,13 @@ contract PlagueGame is IPlagueGame, Ownable, VRFConsumerBaseV2 {
 
         // Initialize the doctors status set on first call
         if (lastHealthyDoctorsSetItemUpdatedCached == 0) {
-            for (uint256 j = 0; j < DOCTORS_STATUS_SET_SIZE; ++j) {
+            uint256 arrayLengthToInitialize = (doctorNumber / 128);
+            for (uint256 j = 0; j < arrayLengthToInitialize; ++j) {
                 doctorsStatusSet[j] = 0x5555555555555555555555555555555555555555555555555555555555555555;
             }
+
+            doctorsStatusSet[arrayLengthToInitialize] =
+                0x5555555555555555555555555555555555555555555555555555555555555555 >> (128 - (doctorNumber % 128)) * 2;
         }
 
         for (uint256 j = lastHealthyDoctorsSetItemUpdatedCached; j < newlastHealthyDoctorsSetItemUpdated; j++) {

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -121,7 +121,19 @@ contract PlagueGameTest is Test {
         doctors.mint(collectionSize);
 
         _gameSetup();
-        _initializeGame();
+
+        plagueGame.initializeGame(200);
+        plagueGame.initializeGame(112);
+
+        vm.expectRevert(GameNotStarted.selector);
+        plagueGame.startGame();
+
+        plagueGame.initializeGame(1);
+
+        vm.expectRevert(TooManyInitialized.selector);
+        plagueGame.initializeGame(1);
+
+        plagueGame.startGame();
 
         doctors.mint(10);
         uint256 extraMintedDoctorId = collectionSize;

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -114,6 +114,30 @@ contract PlagueGameTest is Test {
         assertEq(plagueGame.prizeWithdrawalAllowed(), false, "Withdrawals should be closed");
     }
 
+    function testNoSellout() public {
+        doctors = new ERC721Mock();
+
+        collectionSize /= 2;
+        doctors.mint(collectionSize);
+
+        _gameSetup();
+        _initializeGame();
+
+        doctors.mint(10);
+        uint256 extraMintedDoctorId = collectionSize;
+
+        assertEq(
+            uint256(plagueGame.doctorStatus(extraMintedDoctorId - 1)),
+            uint256(IPlagueGame.Status.Healthy),
+            "Last doctor of the set should be healthy"
+        );
+        assertEq(
+            uint256(plagueGame.doctorStatus(extraMintedDoctorId)),
+            uint256(IPlagueGame.Status.Dead),
+            "Extra doctors minted after game start should be considered dead"
+        );
+    }
+
     function testGame() public {
         assertEq(plagueGame.currentEpoch(), 0, "starting epoch should be 0");
         assertEq(plagueGame.healthyDoctorsNumber(), collectionSize, "all doctors should be healthy");

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -223,7 +223,8 @@ contract PlagueGameTest is Test {
             }
 
             assertEq(
-                plagueGame.deadDoctorsPerEpoch(plagueGame.currentEpoch()),
+                plagueGame.infectedDoctorsPerEpoch(plagueGame.currentEpoch())
+                    - plagueGame.curedDoctorsPerEpoch(plagueGame.currentEpoch()),
                 expectedInfections - doctorsToCure,
                 "The expected number of doctors is dead"
             );

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -12,16 +12,16 @@ error OnlyCoordinatorCanFulfill(address have, address want);
 
 contract PlagueGameTest is Test {
     // Collection configuration
-    uint256 collectionSize = 1200;
+    uint256 collectionSize = 10_000;
     uint256 epochNumber = 12;
-    uint256 playerNumberToEndGame = 10;
+    uint256 playerNumberToEndGame = 100;
     uint256[] infectionPercentagePerEpoch =
         [2_000, 2_000, 2_000, 3_000, 3_000, 3_000, 4_000, 4_000, 4_000, 5_000, 5_000, 5_000];
     uint256 epochDuration = 1 days;
     uint256 prizePot = 100 ether;
 
     // Test configuration
-    uint256[] curedDoctorsPerEpoch = [120, 110, 100, 90, 50, 40, 30, 20, 15, 10, 5, 2];
+    uint256[] curedDoctorsPerEpoch = [1200, 1100, 1000, 900, 500, 400, 300, 200, 150, 100, 50, 20];
     uint256[] randomWords = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     // VRF configuration
@@ -130,7 +130,6 @@ contract PlagueGameTest is Test {
 
         for (uint256 i = 0; i < epochNumber; ++i) {
             uint256 healthyDoctorsEndOfEpoch = plagueGame.getHealthyDoctorsNumber();
-            uint256[] memory deadDoctorsEndOfEpoch = _fetchDoctorsToStatus(IPlagueGame.Status.Dead);
 
             plagueGame.startEpoch();
 
@@ -199,7 +198,7 @@ contract PlagueGameTest is Test {
 
                 assertEq(plagueGame.isGameOver(), true, "Game should be over");
 
-                assertLe(healthyDoctors.length, playerNumberToEndGame, "There should be less than 10 players");
+                assertLe(healthyDoctors.length, playerNumberToEndGame, "There should be less than 100 players");
 
                 break;
             } else {
@@ -214,12 +213,6 @@ contract PlagueGameTest is Test {
 
                 _mockVRFResponse();
             }
-
-            assertEq(
-                _fetchDoctorsToStatus(IPlagueGame.Status.Dead).length - deadDoctorsEndOfEpoch.length,
-                expectedInfections - doctorsToCure,
-                "The expected number of doctors is dead"
-            );
 
             assertEq(
                 plagueGame.deadDoctorsPerEpoch(plagueGame.currentEpoch()),
@@ -363,8 +356,8 @@ contract PlagueGameTest is Test {
     }
 
     function _initializeGame() private {
-        for (uint256 i = 0; i < 10; i++) {
-            plagueGame.initializeGame(collectionSize / 10);
+        for (uint256 i = 0; i < 100; i++) {
+            plagueGame.initializeGame(collectionSize / 100);
         }
 
         vm.expectRevert(TooManyInitialized.selector);

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -262,8 +262,6 @@ contract PlagueGameTest is Test {
 
                     uint256 doctorId = ((setSlot >> offset) & 0xFFFF);
 
-                    console.log(doctorId);
-
                     assertEq(
                         uint256(plagueGame.doctorStatus(doctorId)),
                         uint256(IPlagueGame.Status.Healthy),

--- a/test/PlagueGame.t.sol
+++ b/test/PlagueGame.t.sol
@@ -156,7 +156,8 @@ contract PlagueGameTest is Test {
 
         assertEq(plagueGame.isGameStarted(), true, "game should be started");
 
-        for (uint256 i = 0; i < epochNumber + 10; ++i) {
+        uint256 i;
+        while (true) {
             uint256 healthyDoctorsEndOfEpoch = plagueGame.healthyDoctorsNumber();
 
             vm.expectRevert(InfectionNotComputed.selector);
@@ -254,6 +255,8 @@ contract PlagueGameTest is Test {
             );
 
             assertEq(_fetchDoctorsToStatus(IPlagueGame.Status.Infected).length, 0, "No more infected doctors");
+
+            ++i;
         }
     }
 


### PR DESCRIPTION
Gas optimizations to allow running the game on big sized collections

- Removed the `EnumerableSet`
- Packed doctor statuses and healthy doctors IDs into uints
- Removed events on doctor infected and dead
- Replaced `deadDoctorsPerEpoch` by `curedDoctorsPerEpoch`

`startEpoch` is now paginated for extra safety, using an additional `computeInfectedDoctors` function. `endEpoch` is now very light.