### PR TITLE
Add setGameAddress to the Apothecary

### DIFF
--- a/src/Apothecary.sol
+++ b/src/Apothecary.sol
@@ -15,7 +15,7 @@ import "./IPlagueGame.sol";
 /// @notice Contract used to distribute potions to doctors
 contract Apothecary is IApothecary, Ownable, ReentrancyGuard, VRFConsumerBaseV2 {
     /// @notice Contract address of the plague game
-    IPlagueGame public immutable override plagueGame;
+    IPlagueGame public override plagueGame;
     /// @notice Contract address of the potion NFTs
     ILaunchpeg public immutable override potions;
     /// @notice Contract address of the plague doctor NFTs
@@ -89,8 +89,8 @@ contract Apothecary is IApothecary, Ownable, ReentrancyGuard, VRFConsumerBaseV2 
     ) VRFConsumerBaseV2(address(vrfCoordinator_)) {
         setClaimStartTime(_claimStartTime);
         setDifficulty(difficultyPerEpoch_);
+        setGameAddress(_plagueGame);
 
-        plagueGame = _plagueGame;
         potions = _potions;
         doctors = _doctors;
 
@@ -279,6 +279,20 @@ contract Apothecary is IApothecary, Ownable, ReentrancyGuard, VRFConsumerBaseV2 
         _difficultyPerEpoch = difficultyPerEpoch_;
 
         emit DifficultySet(difficultyPerEpoch_);
+    }
+
+    /// @notice Updates the game address
+    /// @dev Can only be called before the game start, both the previous contract and the new one are checked
+    /// @param _plagueGame New game contract
+    function setGameAddress(IPlagueGame _plagueGame) public override onlyOwner {
+        // On deployment plagueGame is not set yet so we only check the new contract
+        if (_plagueGame.isGameStarted() || (address(plagueGame) != address(0) && plagueGame.isGameStarted())) {
+            revert GameAlreadyStarted();
+        }
+
+        plagueGame = _plagueGame;
+
+        emit GameAddressSet(address(_plagueGame));
     }
 
     /// @notice Transfer potions from owner to the Apothecary contract

--- a/src/IApothecary.sol
+++ b/src/IApothecary.sol
@@ -22,6 +22,7 @@ interface IApothecary {
 
     event ClaimStartTimeSet(uint256 timestamp);
     event DifficultySet(uint256[] difficulty);
+    event GameAddressSet(address plagueGame);
 
     // Contract addresses
     function plagueGame() external view returns (IPlagueGame);
@@ -52,6 +53,7 @@ interface IApothecary {
     // Admin
     function setClaimStartTime(uint256 newClaimStartTime) external;
     function setDifficulty(uint256[] calldata difficultyPerEpoch) external;
+    function setGameAddress(IPlagueGame newGameAddress) external;
     function addPotions(uint256[] calldata potionIds) external;
     function removePotions(uint256 amount) external;
 }

--- a/test/Apothecary.t.sol
+++ b/test/Apothecary.t.sol
@@ -287,6 +287,24 @@ contract ApothecaryTest is PlagueGameTest {
         assertEq(potions.ownerOf(potionIds[1]), address(this), "ADMIN should be the owner of the potion ID");
     }
 
+    function testUpdateGameAddress() public {
+        // redeploy the game contract
+        _gameSetup();
+
+        apothecary.setGameAddress(plagueGame);
+
+        testClaimPotion();
+        // This test makes the game start
+        testMakePotion();
+
+        gameStartTime = block.timestamp + 1 days;
+        _gameSetup();
+
+        // Previous game started so we can't update
+        vm.expectRevert(GameAlreadyStarted.selector);
+        apothecary.setGameAddress(plagueGame);
+    }
+
     /**
      * Helper Functions *
      */


### PR DESCRIPTION
This PR aims provides a way to update the game contract address after deployment. It will only be possible before the game starts, to avoid any side effects.